### PR TITLE
CMTOOL-8, CMTOOL-102, CMTOOL-103, CMTOOL-104, CMTOOL-105, CMTOOL-106,…

### DIFF
--- a/build/src/main/resources/config/environment.properties
+++ b/build/src/main/resources/config/environment.properties
@@ -20,6 +20,12 @@ report.xml.fileName=migration-report.xml
 #target.server.standalone.serverDir=standalone
 #target.server.standalone.configDir=configuration
 
+####### MODULES
+
+#modules.skip=true
+#modules.includes=moduleId1,moduleId2
+#modules.excludes=moduleId3,moduleId4
+
 ### DOMAIN ###
 
 #domain.skip=true

--- a/cli/src/main/java/org/jboss/migration/cli/CommandLineServerMigration.java
+++ b/cli/src/main/java/org/jboss/migration/cli/CommandLineServerMigration.java
@@ -16,9 +16,9 @@
 package org.jboss.migration.cli;
 
 import org.jboss.migration.core.MigrationData;
+import org.jboss.migration.core.ServerMigration;
 import org.jboss.migration.core.ServerMigrationTaskResult;
 import org.jboss.migration.core.env.MigrationEnvironment;
-import org.jboss.migration.core.ServerMigration;
 import org.jboss.migration.core.env.SystemEnvironment;
 import org.jboss.migration.core.logger.ServerMigrationLogger;
 import org.jboss.migration.core.report.HtmlReportWriter;
@@ -28,10 +28,9 @@ import org.wildfly.security.manager.WildFlySecurityManager;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Properties;
 
 /**
@@ -118,7 +117,7 @@ public class CommandLineServerMigration {
             if (baseDir == null) {
                 throw new RuntimeException("system environment does not specifies the tool's base dir");
             }
-            final Path baseDirPath = FileSystems.getDefault().getPath(baseDir);
+            final Path baseDirPath = Paths.get(baseDir);
             final Path configDirPath = baseDirPath.resolve("config");
             final Path outputDirPath = baseDirPath.resolve("output");
 
@@ -186,9 +185,8 @@ public class CommandLineServerMigration {
     }
 
     private static Path resolvePath(String s) throws IllegalArgumentException {
-        final FileSystem fileSystem = FileSystems.getDefault();
-        Path path = fileSystem.getPath(s).normalize();
-        Path absolutePath = path.isAbsolute() ? path : fileSystem.getPath(System.getProperty("user.dir")).resolve(path);
+        Path path = Paths.get(s).normalize();
+        Path absolutePath = path.isAbsolute() ? path : Paths.get(System.getProperty("user.dir")).resolve(path);
         if (!Files.exists(absolutePath)) {
             throw new IllegalArgumentException("File "+absolutePath+" does not exists.");
         } else {

--- a/core/src/main/java/org/jboss/migration/core/env/SkippableByEnvServerMigrationTask.java
+++ b/core/src/main/java/org/jboss/migration/core/env/SkippableByEnvServerMigrationTask.java
@@ -33,6 +33,10 @@ public class SkippableByEnvServerMigrationTask implements ServerMigrationTask {
         this.propertyName = propertyName;
     }
 
+    public SkippableByEnvServerMigrationTask(ServerMigrationTask task) {
+        this(task, task.getName().getName()+".skip");
+    }
+
     @Override
     public ServerMigrationTaskName getName() {
         return task.getName();

--- a/core/src/main/java/org/jboss/migration/core/jboss/ManifestProductInfo.java
+++ b/core/src/main/java/org/jboss/migration/core/jboss/ManifestProductInfo.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2015 Red Hat, Inc.
+ * Copyright 2016 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.migration.core;
+package org.jboss.migration.core.jboss;
+
+import org.jboss.migration.core.ProductInfo;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/core/src/main/java/org/jboss/migration/core/jboss/ModuleIdentifier.java
+++ b/core/src/main/java/org/jboss/migration/core/jboss/ModuleIdentifier.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.migration.core.jboss;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+/**
+ * A unique identifier for a module within a module loader.
+ *
+ * @author <a href="mailto:jbailey@redhat.com">John Bailey</a>
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ * @author Jason T. Greene
+ *
+ * @apiviz.landmark
+ */
+public final class ModuleIdentifier implements Serializable {
+
+    private static final long serialVersionUID = 118533026624827995L;
+
+    private static final String DEFAULT_SLOT = "main";
+
+    private final String name;
+    private final String slot;
+
+    private final transient int hashCode;
+
+    private static final Field hashField;
+
+    static {
+        hashField = AccessController.doPrivileged(new PrivilegedAction<Field>() {
+            public Field run() {
+                final Field field;
+                try {
+                    field = ModuleIdentifier.class.getDeclaredField("hashCode");
+                    field.setAccessible(true);
+                } catch (NoSuchFieldException e) {
+                    throw new NoSuchFieldError(e.getMessage());
+                }
+                return field;
+            }
+        });
+    }
+
+    /**
+     * The class path module (only present if booted from a class path).
+     */
+    public static final ModuleIdentifier CLASSPATH = new ModuleIdentifier("Classpath", DEFAULT_SLOT);
+
+    private ModuleIdentifier(final String name, final String slot) {
+        this.name = name;
+        this.slot = slot;
+        hashCode = calculateHashCode(name, slot);
+    }
+
+    private static int calculateHashCode(final String name, final String slot) {
+        int h = 17;
+        h = 37 * h + name.hashCode();
+        h = 37 * h + slot.hashCode();
+        return h;
+    }
+
+    /**
+     * Get the module name.
+     *
+     * @return the module name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Get the module version slot.
+     *
+     * @return the version slot
+     */
+    public String getSlot() {
+        return slot;
+    }
+
+    /**
+     * Determine whether this object is equal to another.
+     *
+     * @param other the other object
+     * @return {@code true} if they are equal, {@code false} otherwise
+     */
+    public boolean equals(Object other) {
+        return other instanceof ModuleIdentifier && equals((ModuleIdentifier)other);
+    }
+
+    /**
+     * Determine whether this object is equal to another.
+     *
+     * @param other the other object
+     * @return {@code true} if they are equal, {@code false} otherwise
+     */
+    public boolean equals(ModuleIdentifier other) {
+        return this == other || other != null && name.equals(other.name) && slot.equals(other.slot);
+    }
+
+    /**
+     * Determine the hash code of this module identifier.
+     *
+     * @return the hash code
+     */
+    @Override
+    public int hashCode() {
+        return hashCode;
+    }
+
+    /**
+     * Get the string representation of this module identifier.
+     *
+     * @return the string representation
+     */
+    @Override
+    public String toString() {
+        return escapeName(name) + ":" + escapeSlot(slot);
+    }
+
+    private void readObject(ObjectInputStream ois) throws ClassNotFoundException, IOException {
+        ois.defaultReadObject();
+        try {
+            hashField.setInt(this, calculateHashCode(name, slot));
+        } catch (IllegalAccessException e) {
+            throw new IllegalAccessError(e.getMessage());
+        }
+    }
+
+    private static String escapeName(String name) {
+        final StringBuilder b = new StringBuilder();
+        boolean escaped = false;
+        int c;
+        for (int i = 0; i < name.length(); i = name.offsetByCodePoints(i, 1)) {
+            c = name.codePointAt(i);
+            switch (c) {
+                case '\\':
+                case ':':
+                    escaped = true;
+                    b.append('\\');
+                    // fall thru
+                default:
+                    b.appendCodePoint(c);
+            }
+        }
+        return escaped ? b.toString() : name;
+    }
+
+    private static String escapeSlot(String slot) {
+        final StringBuilder b = new StringBuilder();
+        boolean escaped = false;
+        int c;
+        for (int i = 0; i < slot.length(); i = slot.offsetByCodePoints(i, 1)) {
+            c = slot.codePointAt(i);
+            switch (c) {
+                case '\\':
+                    escaped = true;
+                    b.append('\\');
+                    // fall thru
+                default:
+                    b.appendCodePoint(c);
+            }
+        }
+        return escaped ? b.toString() : slot;
+    }
+
+    /**
+     * Parse a module specification from a string.
+     *
+     * @param moduleSpec the specification string
+     * @return the module identifier
+     * @throws IllegalArgumentException if the format of the module specification is invalid or it is {@code null}
+     */
+    public static ModuleIdentifier fromString(String moduleSpec) throws IllegalArgumentException {
+        if (moduleSpec == null) {
+            throw new IllegalArgumentException("Module specification is null");
+        }
+        if (moduleSpec.length() == 0) {
+            throw new IllegalArgumentException("Empty module specification");
+        }
+
+        int c;
+        final StringBuilder b = new StringBuilder();
+        int i = 0;
+        while (i < moduleSpec.length()) {
+            c = moduleSpec.codePointAt(i);
+            if (c == '\\') {
+                b.appendCodePoint(c);
+                i = moduleSpec.offsetByCodePoints(i, 1);
+                if (i < moduleSpec.length()) {
+                    c = moduleSpec.codePointAt(i);
+                    b.appendCodePoint(c);
+                } else {
+                    throw new IllegalArgumentException("Name has an unterminated escape");
+                }
+            } else if (c == ':') {
+                i = moduleSpec.offsetByCodePoints(i, 1);
+                if (i == moduleSpec.length()) {
+                    throw new IllegalArgumentException("Slot is empty");
+                }
+                // end of name, now comes the slot
+                break;
+            } else {
+                b.appendCodePoint(c);
+            }
+            i = moduleSpec.offsetByCodePoints(i, 1);
+        }
+        final String name = b.toString();
+        b.setLength(0);
+        if (i < moduleSpec.length()) do {
+            c = moduleSpec.codePointAt(i);
+            b.appendCodePoint(c);
+            i = moduleSpec.offsetByCodePoints(i, 1);
+        } while (i < moduleSpec.length()); else {
+            return new ModuleIdentifier(name, DEFAULT_SLOT);
+        }
+        return new ModuleIdentifier(name, b.toString());
+    }
+
+    /**
+     * Creates a new module identifier using the specified name and slot.
+     * A slot allows for multiple modules to exist with the same name.
+     * The main usage pattern for this is to differentiate between
+     * two incompatible release streams of a module.
+     *
+     * Normally all module definitions wind up in the "main" slot.
+     * An unspecified or null slot will result in placement in the "main"
+     * slot.
+     *
+     * Unless you have a true need for a slot, it should not be specified.
+     * When in doubt use the {{@link #create(String)} method instead.
+     *
+     * @param name the name of the module
+     * @param slot the slot this module belongs in
+     * @return the identifier
+     */
+    public static ModuleIdentifier create(final String name, String slot) {
+        if (name == null)
+            throw new IllegalArgumentException("Name can not be null");
+
+        if (slot == null)
+            slot = DEFAULT_SLOT;
+
+        return new ModuleIdentifier(name, slot);
+    }
+
+    /**
+     * Creates a new module identifier using the specified name.
+     *
+     * @param name the name of the module
+     * @return the identifier
+     */
+    public static ModuleIdentifier create(String name) {
+        return create(name, null);
+    }
+}

--- a/core/src/main/java/org/jboss/migration/core/jboss/ModuleSpecification.java
+++ b/core/src/main/java/org/jboss/migration/core/jboss/ModuleSpecification.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.migration.core.jboss;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import java.io.BufferedInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static javax.xml.stream.XMLStreamConstants.*;
+
+/**
+ * @author Eduardo Martins
+ */
+public class ModuleSpecification {
+
+    private final ModuleIdentifier moduleIdentifier;
+    private final List<Dependency> dependencies;
+
+    protected ModuleSpecification(Builder builder) {
+        this.moduleIdentifier = builder.moduleIdentifier;
+        this.dependencies = Collections.unmodifiableList(builder.dependencies);
+    }
+
+    public List<Dependency> getDependencies() {
+        return dependencies;
+    }
+
+    public ModuleIdentifier getModuleIdentifier() {
+        return moduleIdentifier;
+    }
+
+    public static class Parser {
+
+        public static ModuleSpecification parse(Path inputFile) throws IOException, XMLStreamException {
+            try (InputStream in = new BufferedInputStream(new FileInputStream(inputFile.toFile()))) {
+                return parse(in);
+            }
+        }
+
+        public static ModuleSpecification parse(final InputStream in) throws IOException, XMLStreamException {
+            XMLStreamReader reader = XMLInputFactory.newInstance().createXMLStreamReader(in);
+            reader.require(START_DOCUMENT, null, null);
+            while (reader.hasNext()) {
+                int type = reader.next();
+                switch (type) {
+                    case START_ELEMENT:
+                        if (reader.getLocalName().equals("module")) {
+                            return parseModule(reader);
+                        }
+                        else if (reader.getLocalName().equals("module-alias")) {
+                            return parseModuleAlias(reader);
+                        }
+                        break;
+                }
+            }
+            throw new XMLStreamException("expected XML elements not found");
+        }
+
+        private static ModuleSpecification parseModule(XMLStreamReader reader) throws XMLStreamException {
+            final int count = reader.getAttributeCount();
+            String name = null;
+            String slot = "main";
+            for (int i = 0; i < count; i++) {
+                if("name".equals(reader.getAttributeName(i).getLocalPart())) {
+                    name = reader.getAttributeValue(i);
+                } else if("slot".equals(reader.getAttributeName(i).getLocalPart())) {
+                    slot = reader.getAttributeValue(i);
+                }
+            }
+            final Builder builder = new Builder(ModuleIdentifier.create(name, slot));
+            while (reader.hasNext()) {
+                int type = reader.next();
+                switch (type) {
+                    case START_ELEMENT:
+                        if (reader.getLocalName().equals("dependencies")) {
+                            parseDependencies(reader, builder);
+                        }
+                    case END_ELEMENT:
+                        if (reader.getLocalName().equals("module")) {
+                            return builder.build();
+                        }
+                }
+            }
+            throw new IllegalStateException("Unexpected end of module.xml");
+        }
+
+        private static ModuleSpecification parseModuleAlias(XMLStreamReader reader) throws XMLStreamException {
+            String targetName = "";
+            String targetSlot = "main";
+            String name = null;
+            String slot = "main";
+            boolean optional = false;
+            for (int i = 0 ; i < reader.getAttributeCount() ; i++) {
+                String localName = reader.getAttributeLocalName(i);
+                if (localName.equals("target-name")) {
+                    targetName = reader.getAttributeValue(i);
+                } else if (localName.equals("target-slot")) {
+                    targetSlot = reader.getAttributeValue(i);
+                } else if (localName.equals("name")) {
+                    name = reader.getAttributeValue(i);
+                } else if (localName.equals("slot")) {
+                    slot = reader.getAttributeValue(i);
+                }
+            }
+            return new Builder(ModuleIdentifier.create(name, slot)).
+                    dependency(new Dependency(ModuleIdentifier.create(targetName, targetSlot), optional))
+                    .build();
+        }
+
+        private static void parseDependencies(XMLStreamReader reader, Builder builder) throws XMLStreamException {
+            while (reader.hasNext()) {
+                int type = reader.next();
+                switch (type) {
+                    case START_ELEMENT:
+                        if (reader.getLocalName().equals("module")) {
+                            String name = "";
+                            String slot = "main";
+                            boolean optional = false;
+                            for (int i = 0 ; i < reader.getAttributeCount() ; i++) {
+                                String localName = reader.getAttributeLocalName(i);
+                                if (localName.equals("name")) {
+                                    name = reader.getAttributeValue(i);
+                                } else if (localName.equals("slot")) {
+                                    slot = reader.getAttributeValue(i);
+                                } else if (localName.equals("optional")) {
+                                    optional = Boolean.parseBoolean(reader.getAttributeValue(i));
+                                }
+                            }
+                            final ModuleIdentifier dependencyId = ModuleIdentifier.create(name, slot);
+                            builder.dependency(new Dependency(dependencyId, optional));
+                        }
+                        break;
+                    case END_ELEMENT:
+                        if (reader.getLocalName().equals("dependencies")) {
+                            return;
+                        }
+                }
+            }
+        }
+    }
+
+    public static class Dependency {
+        private final ModuleIdentifier moduleId;
+        private final boolean optional;
+
+        public Dependency(ModuleIdentifier moduleId, boolean optional) {
+            this.moduleId = moduleId;
+            this.optional = optional;
+        }
+
+        public ModuleIdentifier getId() {
+            return moduleId;
+        }
+
+        public boolean isOptional() {
+            return optional;
+        }
+
+        @Override
+        public String toString() {
+            return "[" + moduleId + (optional ? ",optional=true" : "") + "]";
+        }
+    }
+
+    public static class Builder {
+
+        private final ModuleIdentifier moduleIdentifier;
+        private final List<Dependency> dependencies;
+
+        public Builder(ModuleIdentifier moduleIdentifier) {
+            this.moduleIdentifier = moduleIdentifier;
+            this.dependencies = new ArrayList<>();
+        }
+
+        public Builder dependency(Dependency dependency) {
+            dependencies.add(dependency);
+            return this;
+        }
+
+        public ModuleSpecification build() {
+            return new ModuleSpecification(this);
+        }
+    }
+}

--- a/core/src/main/java/org/jboss/migration/core/jboss/ModulesMigrationTask.java
+++ b/core/src/main/java/org/jboss/migration/core/jboss/ModulesMigrationTask.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.migration.core.jboss;
+
+import org.jboss.migration.core.ServerMigrationTask;
+import org.jboss.migration.core.ServerMigrationTaskContext;
+import org.jboss.migration.core.ServerMigrationTaskName;
+import org.jboss.migration.core.ServerMigrationTaskResult;
+import org.jboss.migration.core.env.MigrationEnvironment;
+import org.jboss.migration.core.env.TaskEnvironment;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author emmartins
+ */
+public class ModulesMigrationTask implements ServerMigrationTask {
+
+    public static final String MODULES = "modules";
+    public static final String ENVIRONMENT_PROPERTIES_PREFIX = MODULES + ".";
+    public static final String ENVIRONMENT_PROPERTY_INCLUDES = ENVIRONMENT_PROPERTIES_PREFIX + "includes";
+    public static final String ENVIRONMENT_PROPERTY_EXCLUDES = ENVIRONMENT_PROPERTIES_PREFIX + "excludes";
+
+    private static final ServerMigrationTaskName TASK_NAME = new ServerMigrationTaskName.Builder(MODULES).build();
+
+    private final JBossServer source;
+    private final JBossServer target;
+    private final String requestedBy;
+
+    public ModulesMigrationTask(JBossServer source, JBossServer target) {
+        this(source, target, "environment");
+    }
+
+    protected ModulesMigrationTask(JBossServer source, JBossServer target, String requestedBy) {
+        this.source = source;
+        this.target = target;
+        this.requestedBy = requestedBy;
+    }
+
+    @Override
+    public ServerMigrationTaskName getName() {
+        return TASK_NAME;
+    }
+
+    @Override
+    public ServerMigrationTaskResult run(ServerMigrationTaskContext context) throws Exception {
+        if (new TaskEnvironment(context.getServerMigrationContext().getMigrationEnvironment(), getName().getName()).isSkippedByEnvironment()) {
+            return ServerMigrationTaskResult.SKIPPED;
+        }
+        context.getLogger().infof("Migrating modules requested by %s...", requestedBy);
+        final ModuleMigrator moduleMigrator = new ModuleMigrator(source, target, context.getServerMigrationContext().getMigrationEnvironment());
+        migrateModules(moduleMigrator, context);
+        if (context.hasSucessfulSubtasks()) {
+            return ServerMigrationTaskResult.SUCCESS;
+        } else {
+            context.getLogger().infof("No modules required migration.", requestedBy);
+            return ServerMigrationTaskResult.SKIPPED;
+        }
+    }
+
+    protected void migrateModules(ModuleMigrator moduleMigrator, ServerMigrationTaskContext context) throws Exception {
+        final List<String> includedModules = context.getServerMigrationContext().getMigrationEnvironment().getPropertyAsList(ENVIRONMENT_PROPERTY_INCLUDES, Collections.<String>emptyList());
+        for (String module : includedModules) {
+            moduleMigrator.migrateModule(module, "requested by environment", context);
+        }
+    }
+
+    public static class ModuleMigrator {
+
+        private final JBossServer.Modules sourceModules;
+        private final JBossServer.Modules targetModules;
+        private final Set<ModuleIdentifier> excludedByEnvironment;
+
+        protected ModuleMigrator(JBossServer source, JBossServer target, MigrationEnvironment environment) {
+            this.sourceModules = source.getModules();
+            this.targetModules = target.getModules();
+            this.excludedByEnvironment = new HashSet<>();
+            for (String excludedModule : environment.getPropertyAsList(ENVIRONMENT_PROPERTY_EXCLUDES, Collections.<String>emptyList())) {
+                this.excludedByEnvironment.add(ModuleIdentifier.fromString(excludedModule));
+            }
+        }
+
+        public void migrateModule(String moduleId, String reason, final ServerMigrationTaskContext context) throws IOException {
+            migrateModule(ModuleIdentifier.fromString(moduleId), reason, context);
+        }
+
+        public void migrateModule(final ModuleIdentifier moduleIdentifier, final String reason, final ServerMigrationTaskContext context) throws IOException {
+            if (excludedByEnvironment.contains(moduleIdentifier)) {
+                context.getLogger().infof("Skipping module %s migration, it's excluded by environment.", moduleIdentifier);
+                return;
+            }
+            final JBossServer.Module sourceModule = sourceModules.getModule(moduleIdentifier);
+            if (sourceModule == null) {
+                throw new IOException("Migration of module "+moduleIdentifier+" required, but module not found in source server.");
+            }
+            if (targetModules.getModule(moduleIdentifier) != null) {
+                context.getLogger().debugf("Skipping module %s migration, already exists in target.", moduleIdentifier, reason);
+                return;
+            }
+            final ServerMigrationTaskName taskName = new ServerMigrationTaskName.Builder("migrate-module").addAttribute("id", moduleIdentifier.toString()).build();
+            final ServerMigrationTask subtask = new ServerMigrationTask() {
+                @Override
+                public ServerMigrationTaskName getName() {
+                    return taskName;
+                }
+
+                @Override
+                public ServerMigrationTaskResult run(ServerMigrationTaskContext context) throws Exception {
+                    context.getServerMigrationContext().getMigrationFiles().copy(sourceModule.getModuleDir(), targetModules.getModuleDir(moduleIdentifier));
+                    context.getLogger().infof("Module %s migrated.", moduleIdentifier);
+                    return new ServerMigrationTaskResult.Builder()
+                            .sucess()
+                            .addAttribute("reason", reason)
+                            .build();
+                }
+            };
+            context.execute(subtask);
+            for (ModuleSpecification.Dependency dependency : sourceModule.getModuleSpecification().getDependencies()) {
+                migrateModule(dependency.getId(), "migrated module " + moduleIdentifier + " depends on it", context);
+            }
+        }
+    }
+}

--- a/eap6-to-eap7/src/main/java/org/jboss/migration/eap6/to/eap7/EAP6_4ToEAP7_0ServerMigrationProvider.java
+++ b/eap6-to-eap7/src/main/java/org/jboss/migration/eap6/to/eap7/EAP6_4ToEAP7_0ServerMigrationProvider.java
@@ -17,6 +17,7 @@ package org.jboss.migration.eap6.to.eap7;
 
 import org.jboss.migration.eap.EAPServer6_4;
 import org.jboss.migration.eap.EAPServerMigrationProvider7_0;
+import org.jboss.migration.wfly10.config.task.module.ConfigurationModulesMigrationTaskFactory;
 import org.jboss.migration.wfly10.config.task.update.AddJmxSubsystemToHosts;
 import org.jboss.migration.eap6.to.eap7.tasks.AddSocketBindingPortExpressions;
 import org.jboss.migration.eap6.to.eap7.tasks.EAPSubsystemUpdates7_0;
@@ -44,6 +45,7 @@ public class EAP6_4ToEAP7_0ServerMigrationProvider implements EAPServerMigration
         return serverUpdateBuilders.serverUpdateBuilder()
                 .standaloneServer(serverUpdateBuilders.standaloneConfigurationBuilder()
                         .subtask(RemoveUnsupportedExtensionsAndSubsystems.INSTANCE)
+                        .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                         .subtask(MigrateSubsystemTasks.JACORB)
                         .subtask(MigrateSubsystemTasks.WEB)
                         .subtask(EAPSubsystemUpdates7_0.UNDERTOW)
@@ -66,6 +68,7 @@ public class EAP6_4ToEAP7_0ServerMigrationProvider implements EAPServerMigration
                 .domain(serverUpdateBuilders.domainBuilder()
                         .domainConfigurations(serverUpdateBuilders.domainConfigurationBuilder()
                                 .subtask(RemoveUnsupportedExtensionsAndSubsystems.INSTANCE)
+                                .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                                 .subtask(MigrateSubsystemTasks.JACORB)
                                 .subtask(MigrateSubsystemTasks.WEB)
                                 .subtask(EAPSubsystemUpdates7_0.UNDERTOW)
@@ -87,6 +90,7 @@ public class EAP6_4ToEAP7_0ServerMigrationProvider implements EAPServerMigration
                                 .build()
                         )
                         .hostConfigurations(serverUpdateBuilders.hostConfigurationBuilder()
+                                .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                                 .subtask(serverUpdateBuilders.hostBuilder()
                                         .subtask(AddJmxSubsystemToHosts.INSTANCE)
                                         .subtask(UpdateUnsecureInterface.INSTANCE)

--- a/eap6-to-eap7/src/main/java/org/jboss/migration/eap6/to/eap7/EAP6_4ToEAP7_1ServerMigrationProvider.java
+++ b/eap6-to-eap7/src/main/java/org/jboss/migration/eap6/to/eap7/EAP6_4ToEAP7_1ServerMigrationProvider.java
@@ -17,6 +17,7 @@ package org.jboss.migration.eap6.to.eap7;
 
 import org.jboss.migration.eap.EAPServer6_4;
 import org.jboss.migration.eap.EAPServerMigrationProvider7_1;
+import org.jboss.migration.wfly10.config.task.module.ConfigurationModulesMigrationTaskFactory;
 import org.jboss.migration.wfly10.to.wfly10.AddLoadBalancerProfile;
 import org.jboss.migration.wfly10.config.task.update.AddJmxSubsystemToHosts;
 import org.jboss.migration.eap6.to.eap7.tasks.AddSocketBindingPortExpressions;
@@ -47,6 +48,7 @@ public class EAP6_4ToEAP7_1ServerMigrationProvider implements EAPServerMigration
         return serverUpdateBuilders.serverUpdateBuilder()
                 .standaloneServer(serverUpdateBuilders.standaloneConfigurationBuilder()
                         .subtask(RemoveUnsupportedExtensionsAndSubsystems.INSTANCE)
+                        .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                         .subtask(MigrateSubsystemTasks.JACORB)
                         .subtask(MigrateSubsystemTasks.WEB)
                         .subtask(EAPSubsystemUpdates7_1.UNDERTOW)
@@ -71,6 +73,7 @@ public class EAP6_4ToEAP7_1ServerMigrationProvider implements EAPServerMigration
                 .domain(serverUpdateBuilders.domainBuilder()
                         .domainConfigurations(serverUpdateBuilders.domainConfigurationBuilder()
                                 .subtask(RemoveUnsupportedExtensionsAndSubsystems.INSTANCE)
+                                .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                                 .subtask(MigrateSubsystemTasks.JACORB)
                                 .subtask(MigrateSubsystemTasks.WEB)
                                 .subtask(EAPSubsystemUpdates7_1.UNDERTOW)
@@ -94,6 +97,7 @@ public class EAP6_4ToEAP7_1ServerMigrationProvider implements EAPServerMigration
                                 .build()
                         )
                         .hostConfigurations(serverUpdateBuilders.hostConfigurationBuilder()
+                                .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                                 .subtask(serverUpdateBuilders.hostBuilder()
                                         .subtask(AddJmxSubsystemToHosts.INSTANCE)
                                         .subtask(UpdateUnsecureInterface.INSTANCE)

--- a/eap6/src/main/java/org/jboss/migration/eap/EAPServer6_4.java
+++ b/eap6/src/main/java/org/jboss/migration/eap/EAPServer6_4.java
@@ -15,7 +15,7 @@
  */
 package org.jboss.migration.eap;
 
-import org.jboss.migration.core.JBossServer;
+import org.jboss.migration.core.jboss.JBossServer;
 import org.jboss.migration.core.ProductInfo;
 import org.jboss.migration.core.env.MigrationEnvironment;
 

--- a/eap6/src/main/java/org/jboss/migration/eap/EAPServerProvider6_4.java
+++ b/eap6/src/main/java/org/jboss/migration/eap/EAPServerProvider6_4.java
@@ -16,15 +16,14 @@
 package org.jboss.migration.eap;
 
 import org.jboss.migration.core.AbstractServerProvider;
-import org.jboss.migration.core.JBossServer;
-import org.jboss.migration.core.ManifestProductInfo;
+import org.jboss.migration.core.jboss.JBossServer;
+import org.jboss.migration.core.jboss.ManifestProductInfo;
 import org.jboss.migration.core.ProductInfo;
 import org.jboss.migration.core.Server;
 import org.jboss.migration.core.env.MigrationEnvironment;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * The EAP 6 {@link org.jboss.migration.core.ServerProvider}.
@@ -34,7 +33,11 @@ public class EAPServerProvider6_4 extends AbstractServerProvider {
 
     @Override
     protected ProductInfo getProductInfo(Path baseDir, MigrationEnvironment migrationEnvironment) throws IllegalArgumentException, IOException {
-        final Path manifestPath = JBossServer.getModulesFile(baseDir, Paths.get("org").resolve("jboss").resolve("as").resolve("product").resolve("eap").resolve("dir").resolve("META-INF").resolve("MANIFEST.MF"));
+        final JBossServer.Module module = new JBossServer.Modules(baseDir).getModule("org.jboss.as.product:eap");
+        if (module == null) {
+            return null;
+        }
+        final Path manifestPath = module.getModuleDir().resolve("dir").resolve("META-INF").resolve("MANIFEST.MF");
         final ManifestProductInfo productInfo = ManifestProductInfo.from(manifestPath);
         return productInfo;
     }

--- a/eap7/src/main/java/org/jboss/migration/eap7/to/eap7/EAP7_0ToEAP7_0ServerMigrationProvider.java
+++ b/eap7/src/main/java/org/jboss/migration/eap7/to/eap7/EAP7_0ToEAP7_0ServerMigrationProvider.java
@@ -19,6 +19,7 @@ package org.jboss.migration.eap7.to.eap7;
 import org.jboss.migration.eap.EAPServer7_0;
 import org.jboss.migration.eap.EAPServerMigrationProvider7_0;
 import org.jboss.migration.wfly10.WildFlyServerMigration10;
+import org.jboss.migration.wfly10.config.task.module.ConfigurationModulesMigrationTaskFactory;
 import org.jboss.migration.wfly10.config.task.update.MigrateCompatibleSecurityRealms;
 import org.jboss.migration.wfly10.config.task.update.RemoveDeployments;
 import org.jboss.migration.wfly10.config.task.update.ServerUpdate;
@@ -34,15 +35,18 @@ public class EAP7_0ToEAP7_0ServerMigrationProvider implements EAPServerMigration
         final ServerUpdate.Builders serverUpdateBuilders = new ServerUpdate.Builders();
         return serverUpdateBuilders.serverUpdateBuilder()
                 .standaloneServer(serverUpdateBuilders.standaloneConfigurationBuilder()
+                        .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                         .subtask(MigrateCompatibleSecurityRealms.INSTANCE)
                         .subtask(RemoveDeployments.INSTANCE)
                 )
                 .domain(serverUpdateBuilders.domainBuilder()
                         .domainConfigurations(serverUpdateBuilders.domainConfigurationBuilder()
+                                .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                                 .subtask(RemoveDeployments.INSTANCE)
                                 .build()
                         )
                         .hostConfigurations(serverUpdateBuilders.hostConfigurationBuilder()
+                                .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                                 .subtask(serverUpdateBuilders.hostBuilder()
                                         .subtask(MigrateCompatibleSecurityRealms.INSTANCE)
                                         .build()

--- a/eap7/src/main/java/org/jboss/migration/eap7/to/eap7/EAP7_0ToEAP7_1ServerMigrationProvider.java
+++ b/eap7/src/main/java/org/jboss/migration/eap7/to/eap7/EAP7_0ToEAP7_1ServerMigrationProvider.java
@@ -19,6 +19,7 @@ package org.jboss.migration.eap7.to.eap7;
 import org.jboss.migration.eap.EAPServer7_0;
 import org.jboss.migration.eap.EAPServerMigrationProvider7_1;
 import org.jboss.migration.wfly10.WildFlyServerMigration10;
+import org.jboss.migration.wfly10.config.task.module.ConfigurationModulesMigrationTaskFactory;
 import org.jboss.migration.wfly10.config.task.update.AddApplicationRealmSSLServerIdentity;
 import org.jboss.migration.wfly10.config.task.update.AddSocketBindingMulticastAddressExpressions;
 import org.jboss.migration.wfly10.config.task.update.MigrateCompatibleSecurityRealms;
@@ -39,6 +40,7 @@ public class EAP7_0ToEAP7_1ServerMigrationProvider implements EAPServerMigration
         return serverUpdateBuilders.serverUpdateBuilder()
                 .standaloneServer(serverUpdateBuilders.standaloneConfigurationBuilder()
                         .subtask(RemoveUnsupportedExtensionsAndSubsystems.INSTANCE)
+                        .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                         .subtask(EAP7_0ToEAP7_1SubsystemUpdates.UNDERTOW)
                         .subtask(EAP7_0ToEAP7_1SubsystemUpdates.INFINISPAN)
                         .subtask(AddSocketBindingMulticastAddressExpressions.INSTANCE)
@@ -49,6 +51,7 @@ public class EAP7_0ToEAP7_1ServerMigrationProvider implements EAPServerMigration
                 .domain(serverUpdateBuilders.domainBuilder()
                         .domainConfigurations(serverUpdateBuilders.domainConfigurationBuilder()
                                 .subtask(RemoveUnsupportedExtensionsAndSubsystems.INSTANCE)
+                                .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                                 .subtask(EAP7_0ToEAP7_1SubsystemUpdates.UNDERTOW)
                                 .subtask(EAP7_0ToEAP7_1SubsystemUpdates.INFINISPAN)
                                 .subtask(AddSocketBindingMulticastAddressExpressions.INSTANCE)
@@ -57,6 +60,7 @@ public class EAP7_0ToEAP7_1ServerMigrationProvider implements EAPServerMigration
                                 .build()
                         )
                         .hostConfigurations(serverUpdateBuilders.hostConfigurationBuilder()
+                                .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                                 .subtask(serverUpdateBuilders.hostBuilder()
                                         .subtask(MigrateCompatibleSecurityRealms.INSTANCE)
                                         .subtask(AddApplicationRealmSSLServerIdentity.INSTANCE)

--- a/eap7/src/main/java/org/jboss/migration/eap7/to/eap7/EAP7_1ToEAP7_1ServerMigrationProvider.java
+++ b/eap7/src/main/java/org/jboss/migration/eap7/to/eap7/EAP7_1ToEAP7_1ServerMigrationProvider.java
@@ -19,6 +19,7 @@ package org.jboss.migration.eap7.to.eap7;
 import org.jboss.migration.eap.EAPServer7_1;
 import org.jboss.migration.eap.EAPServerMigrationProvider7_1;
 import org.jboss.migration.wfly10.WildFlyServerMigration10;
+import org.jboss.migration.wfly10.config.task.module.ConfigurationModulesMigrationTaskFactory;
 import org.jboss.migration.wfly10.config.task.update.MigrateCompatibleSecurityRealms;
 import org.jboss.migration.wfly10.config.task.update.RemoveDeployments;
 import org.jboss.migration.wfly10.config.task.update.ServerUpdate;
@@ -34,15 +35,18 @@ public class EAP7_1ToEAP7_1ServerMigrationProvider implements EAPServerMigration
         final ServerUpdate.Builders serverUpdateBuilders = new ServerUpdate.Builders();
         return serverUpdateBuilders.serverUpdateBuilder()
                 .standaloneServer(serverUpdateBuilders.standaloneConfigurationBuilder()
+                        .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                         .subtask(MigrateCompatibleSecurityRealms.INSTANCE)
                         .subtask(RemoveDeployments.INSTANCE)
                 )
                 .domain(serverUpdateBuilders.domainBuilder()
                         .domainConfigurations(serverUpdateBuilders.domainConfigurationBuilder()
+                                .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                                 .subtask(RemoveDeployments.INSTANCE)
                                 .build()
                         )
                         .hostConfigurations(serverUpdateBuilders.hostConfigurationBuilder()
+                                .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                                 .subtask(serverUpdateBuilders.hostBuilder()
                                         .subtask(MigrateCompatibleSecurityRealms.INSTANCE)
                                         .build()

--- a/pom.xml
+++ b/pom.xml
@@ -59,13 +59,6 @@
             versions, add the artifactId or other qualifier to the property name.
             For example: <version.org.jboss.as.console>
          -->
-        <version.junit>4.11</version.junit>
-
-        <version.org.jboss.logging.jboss-logging>3.3.0.Final</version.org.jboss.logging.jboss-logging>
-        <version.org.jboss.logging.jboss-logging-tools>2.0.1.Final</version.org.jboss.logging.jboss-logging-tools>
-        <version.org.jboss.logmanager.commons-logging-jboss-logmanager>1.0.0.Final</version.org.jboss.logmanager.commons-logging-jboss-logmanager>
-        <version.org.jboss.logmanager.jboss-logmanager>2.0.4.Final</version.org.jboss.logmanager.jboss-logmanager>
-
         <version.org.wildfly.core>3.0.0.Alpha12</version.org.wildfly.core>
 
         <!-- Surefire args -->
@@ -283,50 +276,11 @@
             <!-- External Dependencies -->
 
             <dependency>
-                <groupId>org.jboss.logging</groupId>
-                <artifactId>jboss-logging</artifactId>
-                <version>${version.org.jboss.logging.jboss-logging}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.jboss.logging</groupId>
-                <artifactId>jboss-logging-annotations</artifactId>
-                <version>${version.org.jboss.logging.jboss-logging-tools}</version>
-                <scope>provided</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.jboss.logging</groupId>
-                <artifactId>jboss-logging-processor</artifactId>
-                <version>${version.org.jboss.logging.jboss-logging-tools}</version>
-                <scope>provided</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.jboss.logmanager</groupId>
-                <artifactId>jboss-logmanager</artifactId>
-                <version>${version.org.jboss.logmanager.jboss-logmanager}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.checkstyle</groupId>
-                <artifactId>wildfly-checkstyle-config</artifactId>
-                <version>${version.org.wildfly.checkstyle-config}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>org.wildfly.core</groupId>
-                <version>${version.org.wildfly.core}</version>
-                <artifactId>wildfly-embedded</artifactId>
-            </dependency>
-
-            <!-- Test dependencies -->
-            
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>${version.junit}</version>
-                <scope>test</scope>
+                <artifactId>wildfly-core-parent</artifactId>
+                <version>3.0.0.Alpha12</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
 
         </dependencies>

--- a/wildfly10/src/main/java/org/jboss/migration/wfly10/WildFlyServer10.java
+++ b/wildfly10/src/main/java/org/jboss/migration/wfly10/WildFlyServer10.java
@@ -15,7 +15,7 @@
  */
 package org.jboss.migration.wfly10;
 
-import org.jboss.migration.core.JBossServer;
+import org.jboss.migration.core.jboss.JBossServer;
 import org.jboss.migration.core.ProductInfo;
 import org.jboss.migration.core.Server;
 import org.jboss.migration.core.ServerMigrationTaskContext;

--- a/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/HostConfigurationMigration.java
+++ b/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/HostConfigurationMigration.java
@@ -47,6 +47,11 @@ public class HostConfigurationMigration<S> extends ServerConfigurationMigration<
             return new HostConfigurationMigration<>(this);
         }
 
+        public Builder<S> subtask(final XMLConfigurationSubtaskFactory<S> taskFactory) {
+            builder.subtask(taskFactory);
+            return this;
+        }
+
         public Builder<S> subtask(final HostsManagementTaskFactory<S> taskFactory) {
             builder.subtask(new ManageableServerConfigurationTaskFactory<S, HostControllerConfiguration>() {
                 @Override

--- a/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/module/ConfigurationModulesMigrationTaskFactory.java
+++ b/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/module/ConfigurationModulesMigrationTaskFactory.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.migration.wfly10.config.task.module;
+
+import org.jboss.migration.core.ServerMigrationTask;
+import org.jboss.migration.core.ServerMigrationTaskContext;
+import org.jboss.migration.core.ServerMigrationTaskName;
+import org.jboss.migration.core.ServerPath;
+import org.jboss.migration.core.jboss.JBossServer;
+import org.jboss.migration.core.jboss.ModulesMigrationTask;
+import org.jboss.migration.wfly10.WildFlyServer10;
+import org.jboss.migration.wfly10.config.task.ServerConfigurationMigration;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamReader;
+import java.io.BufferedInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static javax.xml.stream.XMLStreamConstants.START_DOCUMENT;
+import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
+
+/**
+ * @author emmartins
+ */
+public class ConfigurationModulesMigrationTaskFactory<S extends JBossServer<S>> implements ServerConfigurationMigration.XMLConfigurationSubtaskFactory<ServerPath<S>> {
+
+    public static final ConfigurationModulesMigrationTaskFactory TASK_WITH_ALL_DEFAULT_MODULE_FINDERS = new ConfigurationModulesMigrationTaskFactory.Builder()
+            .modulesFinder(new DatasourcesJdbcDriversModulesFinder())
+            .modulesFinder(new DefaultJsfImplModulesFinder())
+            .modulesFinder(new EEGlobalModulesFinder())
+            .modulesFinder(new JMSBridgesModulesFinder())
+            .modulesFinder(new NamingObjectFactoriesModulesFinder())
+            .modulesFinder(new SecurityRealmsPluginModulesFinder())
+            .build();
+
+    private final Map<String, List<ModulesFinder>> modulesFinders;
+
+    protected ConfigurationModulesMigrationTaskFactory(Builder<S> builder) {
+        this.modulesFinders = Collections.unmodifiableMap(builder.modulesFinders);
+    }
+
+    @Override
+    public ServerMigrationTask getTask(final ServerPath<S> source, final Path xmlConfigurationPath, final WildFlyServer10 target) {
+        return new Task(source.getServer(), target, xmlConfigurationPath, modulesFinders);
+    }
+
+    private static class Task extends ModulesMigrationTask {
+
+        private static final ServerMigrationTaskName TASK_NAME = new ServerMigrationTaskName.Builder("configuration-modules").build();
+
+        private final Path xmlConfigurationPath;
+        private final Map<String, List<ModulesFinder>> modulesFinders;
+
+        public Task(JBossServer source, JBossServer target, Path xmlConfigurationPath, Map<String, List<ModulesFinder>> modulesFinders) {
+            super(source, target, "configuration");
+            this.xmlConfigurationPath = xmlConfigurationPath;
+            this.modulesFinders = modulesFinders;
+        }
+
+        @Override
+        public ServerMigrationTaskName getName() {
+            return TASK_NAME;
+        }
+
+        @Override
+        protected void migrateModules(ModuleMigrator moduleMigrator, ServerMigrationTaskContext context) throws Exception {
+            try (InputStream in = new BufferedInputStream(new FileInputStream(xmlConfigurationPath.toFile()))) {
+                XMLStreamReader reader = XMLInputFactory.newInstance().createXMLStreamReader(in);
+                reader.require(START_DOCUMENT, null, null);
+                while (reader.hasNext()) {
+                    if (reader.next() == START_ELEMENT) {
+                        processElement(reader, moduleMigrator, context);
+                    }
+                }
+            }
+        }
+
+        protected void processElement(XMLStreamReader reader, ModuleMigrator moduleMigrator, ServerMigrationTaskContext context) throws IOException {
+            final List<ModulesFinder> elementModulesFinders = modulesFinders.get(reader.getLocalName());
+            if (elementModulesFinders != null) {
+                for (ModulesFinder modulesFinder : elementModulesFinders) {
+                    modulesFinder.processElement(reader, moduleMigrator, context);
+                }
+            }
+        }
+    }
+    /**
+     * A module finder.
+     */
+    public interface ModulesFinder {
+        /**
+         * The XML Element's local name the processor is interested.
+         * @return
+         */
+        String getElementLocalName();
+        /**
+         *
+         * @param reader the XML stream reader, positioned at the start of an element of interest
+         * @param moduleMigrator the module migrator
+         */
+        void processElement(XMLStreamReader reader, ModulesMigrationTask.ModuleMigrator moduleMigrator, ServerMigrationTaskContext context) throws IOException;
+    }
+
+    public static class Builder<S extends JBossServer<S>> {
+        private final Map<String, List<ModulesFinder>> modulesFinders = new HashMap<>();
+
+        public synchronized Builder<S> modulesFinder(ModulesFinder modulesFinder) {
+            List<ModulesFinder> elementModulesFinders = modulesFinders.get(modulesFinder.getElementLocalName());
+            if (elementModulesFinders == null) {
+                elementModulesFinders = new ArrayList<>();
+                modulesFinders.put(modulesFinder.getElementLocalName(), elementModulesFinders);
+            }
+            elementModulesFinders.add(modulesFinder);
+            return this;
+        }
+
+        public ConfigurationModulesMigrationTaskFactory<S> build() {
+            return new ConfigurationModulesMigrationTaskFactory<>(this);
+        }
+    }
+}

--- a/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/module/DatasourcesJdbcDriversModulesFinder.java
+++ b/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/module/DatasourcesJdbcDriversModulesFinder.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.migration.wfly10.config.task.module;
+
+import org.jboss.migration.core.ServerMigrationTaskContext;
+import org.jboss.migration.core.jboss.ModulesMigrationTask;
+import org.jboss.migration.wfly10.config.task.subsystem.SubsystemNames;
+
+import javax.xml.stream.XMLStreamReader;
+import java.io.IOException;
+
+/**
+ * Finds modules referenced by Datasources subsystem configs, as source of JDBC driver.
+ * @author emmartins
+ */
+public class DatasourcesJdbcDriversModulesFinder implements ConfigurationModulesMigrationTaskFactory.ModulesFinder {
+    @Override
+    public String getElementLocalName() {
+        return "driver";
+    }
+
+    @Override
+    public void processElement(XMLStreamReader reader, ModulesMigrationTask.ModuleMigrator moduleMigrator, ServerMigrationTaskContext context) throws IOException {
+        final String namespaceURI = reader.getNamespaceURI();
+        if (namespaceURI == null || !namespaceURI.startsWith("urn:jboss:domain:"+ SubsystemNames.DATASOURCES)) {
+            return;
+        }
+        final String moduleId = reader.getAttributeValue(null, "module");
+        if (moduleId != null) {
+            moduleMigrator.migrateModule(moduleId, "Referenced as the source of a datasource JDBC driver", context);
+        }
+    }
+}

--- a/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/module/DefaultJsfImplModulesFinder.java
+++ b/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/module/DefaultJsfImplModulesFinder.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.migration.wfly10.config.task.module;
+
+import org.jboss.migration.core.ServerMigrationTaskContext;
+import org.jboss.migration.core.jboss.ModulesMigrationTask;
+import org.jboss.migration.wfly10.config.task.subsystem.SubsystemNames;
+
+import javax.xml.stream.XMLStreamReader;
+import java.io.IOException;
+
+/**
+ * Finds modules referenced by JSF subsystem configs, as source of default JSF implementation.
+ * @author emmartins
+ */
+public class DefaultJsfImplModulesFinder implements ConfigurationModulesMigrationTaskFactory.ModulesFinder {
+    @Override
+    public String getElementLocalName() {
+        return "subsystem";
+    }
+
+    @Override
+    public void processElement(XMLStreamReader reader, ModulesMigrationTask.ModuleMigrator moduleMigrator, ServerMigrationTaskContext context) throws IOException {
+        final String namespaceURI = reader.getNamespaceURI();
+        if (namespaceURI == null || !namespaceURI.startsWith("urn:jboss:domain:"+ SubsystemNames.JSF)) {
+            return;
+        }
+        final String moduleId = reader.getAttributeValue(null, "default-jsf-impl-slot");
+        if (moduleId != null) {
+            moduleMigrator.migrateModule(moduleId, "Referenced as the source of default JSF implementation", context);
+        }
+    }
+}

--- a/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/module/EEGlobalModulesFinder.java
+++ b/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/module/EEGlobalModulesFinder.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.migration.wfly10.config.task.module;
+
+import org.jboss.migration.core.ServerMigrationTaskContext;
+import org.jboss.migration.core.jboss.ModuleIdentifier;
+import org.jboss.migration.core.jboss.ModulesMigrationTask;
+import org.jboss.migration.wfly10.config.task.subsystem.SubsystemNames;
+
+import javax.xml.stream.XMLStreamReader;
+import java.io.IOException;
+
+/**
+ * Finds global modules referenced by EE subsystem configs.
+ * @author emmartins
+ */
+public class EEGlobalModulesFinder implements ConfigurationModulesMigrationTaskFactory.ModulesFinder {
+    @Override
+    public String getElementLocalName() {
+        return "module";
+    }
+
+    @Override
+    public void processElement(XMLStreamReader reader, ModulesMigrationTask.ModuleMigrator moduleMigrator, ServerMigrationTaskContext context) throws IOException {
+        final String namespaceURI = reader.getNamespaceURI();
+        if (namespaceURI == null || !namespaceURI.startsWith("urn:jboss:domain:"+ SubsystemNames.EE)) {
+            return;
+        }
+        final String name = reader.getAttributeValue(null, "name");
+        String slot = reader.getAttributeValue(null, "slot");
+        if (slot == null) {
+            slot = "main";
+        }
+        moduleMigrator.migrateModule(ModuleIdentifier.create(name, slot), "EE Subsystem's Global Module", context);
+    }
+}

--- a/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/module/JMSBridgesModulesFinder.java
+++ b/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/module/JMSBridgesModulesFinder.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.migration.wfly10.config.task.module;
+
+import org.jboss.migration.core.ServerMigrationTaskContext;
+import org.jboss.migration.core.jboss.ModulesMigrationTask;
+import org.jboss.migration.wfly10.config.task.subsystem.SubsystemNames;
+
+import javax.xml.stream.XMLStreamReader;
+import java.io.IOException;
+
+/**
+ * Finds modules referenced by Messaging subsystem configs, as source of JMS Bridges.
+ * @author emmartins
+ */
+public class JMSBridgesModulesFinder implements ConfigurationModulesMigrationTaskFactory.ModulesFinder {
+    @Override
+    public String getElementLocalName() {
+        return "jms-bridge";
+    }
+
+    @Override
+    public void processElement(XMLStreamReader reader, ModulesMigrationTask.ModuleMigrator moduleMigrator, ServerMigrationTaskContext context) throws IOException {
+        final String namespaceURI = reader.getNamespaceURI();
+        if (namespaceURI == null || !namespaceURI.startsWith("urn:jboss:domain:"+ SubsystemNames.MESSAGING_ACTIVEMQ)) {
+            return;
+        }
+        moduleMigrator.migrateModule(reader.getAttributeValue(null, "module"), "Required by JMS Bridge "+reader.getAttributeValue(null, "name"), context);
+    }
+
+    /*
+    <jms-bridge name="myBridge" module="org.acmemq">
+      <source connection-factory="ConnectionFactory"
+              destination="sourceQ"
+              user="user1"
+              password="pwd1"
+              quality-of-service="AT_MOST_ONCE"
+              failure-retry-interval="500"
+              max-retries="1"
+              max-batch-size="500"
+              max-batch-time="500"
+              add-messageID-in-header="true">
+         <source-context>
+            <property name="java.naming.factory.initial"
+                      value="org.acmemq.jndi.AcmeMQInitialContextFactory"/>
+            <property name="java.naming.provider.url"
+                      value="tcp://127.0.0.1:9292"/>
+         </source-context>
+      </source>
+      <target connection-factory"/jms/invmTargetCF"
+              destination="/jms/targetQ" />
+      </target>
+   </jms-bridge>
+     */
+}

--- a/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/module/NamingObjectFactoriesModulesFinder.java
+++ b/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/module/NamingObjectFactoriesModulesFinder.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.migration.wfly10.config.task.module;
+
+import org.jboss.migration.core.ServerMigrationTaskContext;
+import org.jboss.migration.core.jboss.ModulesMigrationTask;
+import org.jboss.migration.wfly10.config.task.subsystem.SubsystemNames;
+
+import javax.xml.stream.XMLStreamReader;
+import java.io.IOException;
+
+/**
+ * Finds modules referenced by Naming subsystem configs, as source of Object Factories.
+ * @author emmartins
+ */
+public class NamingObjectFactoriesModulesFinder implements ConfigurationModulesMigrationTaskFactory.ModulesFinder {
+    @Override
+    public String getElementLocalName() {
+        return "object-factory";
+    }
+
+    @Override
+    public void processElement(XMLStreamReader reader, ModulesMigrationTask.ModuleMigrator moduleMigrator, ServerMigrationTaskContext context) throws IOException {
+        final String namespaceURI = reader.getNamespaceURI();
+        if (namespaceURI == null || !namespaceURI.startsWith("urn:jboss:domain:"+ SubsystemNames.NAMING)) {
+            return;
+        }
+        moduleMigrator.migrateModule(reader.getAttributeValue(null, "module"), "Required by Naming's object factory "+reader.getAttributeValue(null, "name"), context);
+    }
+}

--- a/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/module/SecurityRealmsPluginModulesFinder.java
+++ b/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/module/SecurityRealmsPluginModulesFinder.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.migration.wfly10.config.task.module;
+
+import org.jboss.migration.core.ServerMigrationTaskContext;
+import org.jboss.migration.core.jboss.ModulesMigrationTask;
+
+import javax.xml.stream.XMLStreamReader;
+import java.io.IOException;
+
+/**
+ * Finds global modules referenced by EE subsystem configs.
+ * @author emmartins
+ */
+public class SecurityRealmsPluginModulesFinder implements ConfigurationModulesMigrationTaskFactory.ModulesFinder {
+    @Override
+    public String getElementLocalName() {
+        return "plug-in";
+    }
+
+    @Override
+    public void processElement(XMLStreamReader reader, ModulesMigrationTask.ModuleMigrator moduleMigrator, ServerMigrationTaskContext context) throws IOException {
+        final String namespaceURI = reader.getNamespaceURI();
+        if (namespaceURI == null || !namespaceURI.startsWith("urn:jboss:domain:")) {
+            return;
+        }
+        moduleMigrator.migrateModule(reader.getAttributeValue(null, "module"), "Requird by Security Realm plugin", context);
+    }
+}

--- a/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/update/AddApplicationRealmSSLServerIdentity.java
+++ b/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/update/AddApplicationRealmSSLServerIdentity.java
@@ -19,7 +19,7 @@ package org.jboss.migration.wfly10.config.task.update;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.dmr.ModelNode;
-import org.jboss.migration.core.JBossServer;
+import org.jboss.migration.core.jboss.JBossServer;
 import org.jboss.migration.core.ServerMigrationTask;
 import org.jboss.migration.core.ServerMigrationTaskContext;
 import org.jboss.migration.core.ServerMigrationTaskName;

--- a/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/update/CopySourceXMLConfiguration.java
+++ b/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/update/CopySourceXMLConfiguration.java
@@ -16,7 +16,7 @@
 
 package org.jboss.migration.wfly10.config.task.update;
 
-import org.jboss.migration.core.JBossServer;
+import org.jboss.migration.core.jboss.JBossServer;
 import org.jboss.migration.core.ServerMigrationTaskContext;
 import org.jboss.migration.core.ServerPath;
 import org.jboss.migration.wfly10.WildFlyServer10;

--- a/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/update/DomainConfigurationsUpdate.java
+++ b/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/update/DomainConfigurationsUpdate.java
@@ -16,7 +16,7 @@
 
 package org.jboss.migration.wfly10.config.task.update;
 
-import org.jboss.migration.core.JBossServer;
+import org.jboss.migration.core.jboss.JBossServer;
 import org.jboss.migration.core.ServerPath;
 import org.jboss.migration.wfly10.WildFlyServer10;
 import org.jboss.migration.wfly10.config.task.DomainConfigurationMigration;

--- a/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/update/DomainUpdate.java
+++ b/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/update/DomainUpdate.java
@@ -16,7 +16,7 @@
 
 package org.jboss.migration.wfly10.config.task.update;
 
-import org.jboss.migration.core.JBossServer;
+import org.jboss.migration.core.jboss.JBossServer;
 import org.jboss.migration.core.ServerPath;
 import org.jboss.migration.wfly10.config.task.DomainConfigurationMigration;
 import org.jboss.migration.wfly10.config.task.DomainMigration;

--- a/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/update/HostConfigurationsUpdate.java
+++ b/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/update/HostConfigurationsUpdate.java
@@ -16,7 +16,7 @@
 
 package org.jboss.migration.wfly10.config.task.update;
 
-import org.jboss.migration.core.JBossServer;
+import org.jboss.migration.core.jboss.JBossServer;
 import org.jboss.migration.core.ServerPath;
 import org.jboss.migration.wfly10.WildFlyServer10;
 import org.jboss.migration.wfly10.config.task.HostConfigurationMigration;

--- a/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/update/HostUpdate.java
+++ b/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/update/HostUpdate.java
@@ -16,7 +16,7 @@
 
 package org.jboss.migration.wfly10.config.task.update;
 
-import org.jboss.migration.core.JBossServer;
+import org.jboss.migration.core.jboss.JBossServer;
 import org.jboss.migration.core.ServerPath;
 import org.jboss.migration.wfly10.config.management.HostConfiguration;
 import org.jboss.migration.wfly10.config.task.HostMigration;

--- a/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/update/MigrateCompatibleSecurityRealms.java
+++ b/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/update/MigrateCompatibleSecurityRealms.java
@@ -20,7 +20,7 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.dmr.ModelNode;
-import org.jboss.migration.core.JBossServer;
+import org.jboss.migration.core.jboss.JBossServer;
 import org.jboss.migration.core.ParentServerMigrationTask;
 import org.jboss.migration.core.Server;
 import org.jboss.migration.core.ServerMigrationTask;

--- a/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/update/ServerUpdate.java
+++ b/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/update/ServerUpdate.java
@@ -16,8 +16,11 @@
 
 package org.jboss.migration.wfly10.config.task.update;
 
-import org.jboss.migration.core.JBossServer;
+import org.jboss.migration.core.ServerMigrationTask;
+import org.jboss.migration.core.jboss.JBossServer;
 import org.jboss.migration.core.ServerPath;
+import org.jboss.migration.core.jboss.ModulesMigrationTask;
+import org.jboss.migration.wfly10.WildFlyServer10;
 import org.jboss.migration.wfly10.config.management.HostConfiguration;
 import org.jboss.migration.wfly10.config.management.HostControllerConfiguration;
 import org.jboss.migration.wfly10.config.management.StandaloneServerConfiguration;
@@ -45,10 +48,23 @@ public class ServerUpdate<S extends JBossServer<S>> extends ServerMigration<S> {
 
     public static class Builder<S extends JBossServer<S>> extends ServerMigration.Builder<S> {
 
+        public Builder() {
+            subtask(new SubtaskFactory<S>() {
+                @Override
+                public ServerMigrationTask getTask(S source, WildFlyServer10 target) {
+                    return new ModulesMigrationTask(source, target);
+                }
+            });
+        }
+
         @Override
         public Builder<S> subtask(SubtaskFactory<S> subtaskFactory) {
             super.subtask(subtaskFactory);
             return this;
+        }
+
+        public Builder<S> migrate(DomainMigration<S> domainUpdate) {
+            return subtask(domainUpdate);
         }
 
         public Builder<S> domain(DomainMigration<S> domainUpdate) {

--- a/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/update/StandaloneServerConfigurationsUpdate.java
+++ b/wildfly10/src/main/java/org/jboss/migration/wfly10/config/task/update/StandaloneServerConfigurationsUpdate.java
@@ -16,7 +16,7 @@
 
 package org.jboss.migration.wfly10.config.task.update;
 
-import org.jboss.migration.core.JBossServer;
+import org.jboss.migration.core.jboss.JBossServer;
 import org.jboss.migration.core.ServerPath;
 import org.jboss.migration.wfly10.WildFlyServer10;
 import org.jboss.migration.wfly10.config.task.ServerConfigurationsMigration;

--- a/wildfly10/src/main/java/org/jboss/migration/wfly10/dist/full/WildFlyFullServerProvider10_0.java
+++ b/wildfly10/src/main/java/org/jboss/migration/wfly10/dist/full/WildFlyFullServerProvider10_0.java
@@ -16,15 +16,14 @@
 package org.jboss.migration.wfly10.dist.full;
 
 import org.jboss.migration.core.AbstractServerProvider;
-import org.jboss.migration.core.JBossServer;
-import org.jboss.migration.core.ManifestProductInfo;
+import org.jboss.migration.core.jboss.JBossServer;
+import org.jboss.migration.core.jboss.ManifestProductInfo;
 import org.jboss.migration.core.ProductInfo;
 import org.jboss.migration.core.Server;
 import org.jboss.migration.core.env.MigrationEnvironment;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * The WildFly 10 Full {@link org.jboss.migration.core.ServerProvider}.
@@ -33,7 +32,11 @@ import java.nio.file.Paths;
 public class WildFlyFullServerProvider10_0 extends AbstractServerProvider {
 
     protected ProductInfo getProductInfo(Path baseDir, MigrationEnvironment migrationEnvironment) throws IllegalArgumentException, IOException {
-        final Path manifestPath = JBossServer.getModulesFile(baseDir, Paths.get("org").resolve("jboss").resolve("as").resolve("product").resolve("wildfly-full").resolve("dir").resolve("META-INF").resolve("MANIFEST.MF"));
+        final JBossServer.Module module = new JBossServer.Modules(baseDir).getModule("org.jboss.as.product:wildfly-full");
+        if (module == null) {
+            return null;
+        }
+        final Path manifestPath = module.getModuleDir().resolve("dir").resolve("META-INF").resolve("MANIFEST.MF");
         final ManifestProductInfo productInfo = ManifestProductInfo.from(manifestPath);
         return productInfo;
     }

--- a/wildfly10/src/main/java/org/jboss/migration/wfly10/to/wfly10/WildFly10_0ToWildFly10_1ServerMigrationProvider.java
+++ b/wildfly10/src/main/java/org/jboss/migration/wfly10/to/wfly10/WildFly10_0ToWildFly10_1ServerMigrationProvider.java
@@ -18,6 +18,7 @@ package org.jboss.migration.wfly10.to.wfly10;
 
 import org.jboss.migration.wfly10.WildFlyServer10;
 import org.jboss.migration.wfly10.WildFlyServerMigration10;
+import org.jboss.migration.wfly10.config.task.module.ConfigurationModulesMigrationTaskFactory;
 import org.jboss.migration.wfly10.config.task.update.AddApplicationRealmSSLServerIdentity;
 import org.jboss.migration.wfly10.config.task.update.MigrateCompatibleSecurityRealms;
 import org.jboss.migration.wfly10.config.task.update.RemoveDeployments;
@@ -39,6 +40,7 @@ public class WildFly10_0ToWildFly10_1ServerMigrationProvider implements WildFlyF
         return serverUpdateBuilders.serverUpdateBuilder()
                 .standaloneServer(serverUpdateBuilders.standaloneConfigurationBuilder()
                         .subtask(RemoveUnsupportedExtensionsAndSubsystems.INSTANCE)
+                        .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                         .subtask(WildFly10_0ToWildFly10_1SubsystemUpdates.UNDERTOW)
                         .subtask(WildFly10_0ToWildFly10_1SubsystemUpdates.INFINISPAN)
                         .subtask(AddSocketBindingMulticastAddressExpressions.INSTANCE)
@@ -49,6 +51,7 @@ public class WildFly10_0ToWildFly10_1ServerMigrationProvider implements WildFlyF
                 .domain(serverUpdateBuilders.domainBuilder()
                         .domainConfigurations(serverUpdateBuilders.domainConfigurationBuilder()
                                 .subtask(RemoveUnsupportedExtensionsAndSubsystems.INSTANCE)
+                                .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                                 .subtask(WildFly10_0ToWildFly10_1SubsystemUpdates.UNDERTOW)
                                 .subtask(WildFly10_0ToWildFly10_1SubsystemUpdates.INFINISPAN)
                                 .subtask(AddSocketBindingMulticastAddressExpressions.INSTANCE)
@@ -57,6 +60,7 @@ public class WildFly10_0ToWildFly10_1ServerMigrationProvider implements WildFlyF
                                 .build()
                         )
                         .hostConfigurations(serverUpdateBuilders.hostConfigurationBuilder()
+                                .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                                 .subtask(serverUpdateBuilders.hostBuilder()
                                         .subtask(MigrateCompatibleSecurityRealms.INSTANCE)
                                         .subtask(AddApplicationRealmSSLServerIdentity.INSTANCE)

--- a/wildfly10/src/main/java/org/jboss/migration/wfly10/to/wfly10/WildFly10_1ToWildFly10_1ServerMigrationProvider.java
+++ b/wildfly10/src/main/java/org/jboss/migration/wfly10/to/wfly10/WildFly10_1ToWildFly10_1ServerMigrationProvider.java
@@ -18,6 +18,7 @@ package org.jboss.migration.wfly10.to.wfly10;
 
 import org.jboss.migration.wfly10.WildFlyServer10;
 import org.jboss.migration.wfly10.WildFlyServerMigration10;
+import org.jboss.migration.wfly10.config.task.module.ConfigurationModulesMigrationTaskFactory;
 import org.jboss.migration.wfly10.config.task.update.MigrateCompatibleSecurityRealms;
 import org.jboss.migration.wfly10.config.task.update.RemoveDeployments;
 import org.jboss.migration.wfly10.config.task.update.ServerUpdate;
@@ -35,17 +36,20 @@ public class WildFly10_1ToWildFly10_1ServerMigrationProvider implements WildFlyF
         final ServerUpdate.Builders<WildFlyServer10> serverUpdateBuilders = new ServerUpdate.Builders<>();
         return serverUpdateBuilders.serverUpdateBuilder()
                 .standaloneServer(serverUpdateBuilders.standaloneConfigurationBuilder()
+                        .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                         .subtask(WildFly10_1ToWildFly10_1SubsystemUpdates.UNDERTOW)
                         .subtask(MigrateCompatibleSecurityRealms.INSTANCE)
                         .subtask(RemoveDeployments.INSTANCE)
                 )
                 .domain(serverUpdateBuilders.domainBuilder()
                         .domainConfigurations(serverUpdateBuilders.domainConfigurationBuilder()
+                                .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                                 .subtask(WildFly10_1ToWildFly10_1SubsystemUpdates.UNDERTOW)
                                 .subtask(RemoveDeployments.INSTANCE)
                                 .build()
                         )
                         .hostConfigurations(serverUpdateBuilders.hostConfigurationBuilder()
+                                .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                                 .subtask(serverUpdateBuilders.hostBuilder()
                                         .subtask(MigrateCompatibleSecurityRealms.INSTANCE)
                                         .build()

--- a/wildfly8-to-eap7/src/main/java/org/jboss/migration/wfly8/to/eap7/WildFly8ToEAP7_0ServerMigrationProvider.java
+++ b/wildfly8-to-eap7/src/main/java/org/jboss/migration/wfly8/to/eap7/WildFly8ToEAP7_0ServerMigrationProvider.java
@@ -17,6 +17,7 @@ package org.jboss.migration.wfly8.to.eap7;
 
 import org.jboss.migration.eap.EAPServerMigrationProvider7_0;
 import org.jboss.migration.wfly10.WildFlyServerMigration10;
+import org.jboss.migration.wfly10.config.task.module.ConfigurationModulesMigrationTaskFactory;
 import org.jboss.migration.wfly10.config.task.update.AddJmxSubsystemToHosts;
 import org.jboss.migration.wfly10.config.task.update.AddPrivateInterface;
 import org.jboss.migration.wfly10.config.task.update.AddSubsystemTasks;
@@ -42,6 +43,7 @@ public class WildFly8ToEAP7_0ServerMigrationProvider implements EAPServerMigrati
         return serverUpdateBuilders.serverUpdateBuilder()
                 .standaloneServer(serverUpdateBuilders.standaloneConfigurationBuilder()
                         .subtask(RemoveUnsupportedExtensionsAndSubsystems.INSTANCE)
+                        .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                         .subtask(MigrateSubsystemTasks.JACORB)
                         .subtask(MigrateSubsystemTasks.MESSAGING)
                         .subtask(WildFly8ToEAP7_0SubsystemUpdates.INFINISPAN)
@@ -57,6 +59,7 @@ public class WildFly8ToEAP7_0ServerMigrationProvider implements EAPServerMigrati
                 .domain(serverUpdateBuilders.domainBuilder()
                         .domainConfigurations(serverUpdateBuilders.domainConfigurationBuilder()
                                 .subtask(RemoveUnsupportedExtensionsAndSubsystems.INSTANCE)
+                                .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                                 .subtask(MigrateSubsystemTasks.JACORB)
                                 .subtask(MigrateSubsystemTasks.MESSAGING)
                                 .subtask(WildFly8ToEAP7_0SubsystemUpdates.INFINISPAN)
@@ -71,6 +74,7 @@ public class WildFly8ToEAP7_0ServerMigrationProvider implements EAPServerMigrati
                                 .subtask(RemoveDeployments.INSTANCE)
                         )
                         .hostConfigurations(serverUpdateBuilders.hostConfigurationBuilder()
+                                .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                                 .subtask(serverUpdateBuilders.hostBuilder()
                                         .subtask(AddJmxSubsystemToHosts.INSTANCE)
                                         .subtask(UpdateUnsecureInterface.INSTANCE)

--- a/wildfly8-to-wildfly10/src/main/java/org/jboss/migration/wfly8/to/wfly10/WildFly8ToWildFly10_1ServerMigrationProvider.java
+++ b/wildfly8-to-wildfly10/src/main/java/org/jboss/migration/wfly8/to/wfly10/WildFly8ToWildFly10_1ServerMigrationProvider.java
@@ -16,6 +16,7 @@
 package org.jboss.migration.wfly8.to.wfly10;
 
 import org.jboss.migration.wfly10.WildFlyServerMigration10;
+import org.jboss.migration.wfly10.config.task.module.ConfigurationModulesMigrationTaskFactory;
 import org.jboss.migration.wfly10.config.task.update.AddApplicationRealmSSLServerIdentity;
 import org.jboss.migration.wfly10.config.task.update.AddJmxSubsystemToHosts;
 import org.jboss.migration.wfly10.config.task.update.AddPrivateInterface;
@@ -44,6 +45,7 @@ public class WildFly8ToWildFly10_1ServerMigrationProvider implements WildFlyFull
         return serverUpdateBuilders.serverUpdateBuilder()
                 .standaloneServer(serverUpdateBuilders.standaloneConfigurationBuilder()
                         .subtask(RemoveUnsupportedExtensionsAndSubsystems.INSTANCE)
+                        .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                         .subtask(WildFly8ToWildFly10_1SubsystemUpdates.INFINISPAN)
                         .subtask(WildFly8ToWildFly10_1SubsystemUpdates.UNDERTOW)
                         .subtask(MigrateSubsystemTasks.JACORB)
@@ -61,6 +63,7 @@ public class WildFly8ToWildFly10_1ServerMigrationProvider implements WildFlyFull
                 .domain(serverUpdateBuilders.domainBuilder()
                         .domainConfigurations(serverUpdateBuilders.domainConfigurationBuilder()
                                 .subtask(RemoveUnsupportedExtensionsAndSubsystems.INSTANCE)
+                                .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                                 .subtask(WildFly8ToWildFly10_1SubsystemUpdates.INFINISPAN)
                                 .subtask(WildFly8ToWildFly10_1SubsystemUpdates.UNDERTOW)
                                 .subtask(MigrateSubsystemTasks.JACORB)
@@ -77,6 +80,7 @@ public class WildFly8ToWildFly10_1ServerMigrationProvider implements WildFlyFull
                                 .subtask(RemoveDeployments.INSTANCE)
                         )
                         .hostConfigurations(serverUpdateBuilders.hostConfigurationBuilder()
+                                .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                                 .subtask(serverUpdateBuilders.hostBuilder()
                                         .subtask(AddJmxSubsystemToHosts.INSTANCE)
                                         .subtask(UpdateUnsecureInterface.INSTANCE)

--- a/wildfly8/src/main/java/org/jboss/migration/wfly8/WildFlyServer8.java
+++ b/wildfly8/src/main/java/org/jboss/migration/wfly8/WildFlyServer8.java
@@ -15,7 +15,7 @@
  */
 package org.jboss.migration.wfly8;
 
-import org.jboss.migration.core.JBossServer;
+import org.jboss.migration.core.jboss.JBossServer;
 import org.jboss.migration.core.ProductInfo;
 import org.jboss.migration.core.env.MigrationEnvironment;
 

--- a/wildfly8/src/main/java/org/jboss/migration/wfly8/WildFlyServerProvider8.java
+++ b/wildfly8/src/main/java/org/jboss/migration/wfly8/WildFlyServerProvider8.java
@@ -16,10 +16,11 @@
 package org.jboss.migration.wfly8;
 
 import org.jboss.migration.core.AbstractServerProvider;
-import org.jboss.migration.core.JBossServer;
+import org.jboss.migration.core.jboss.JBossServer;
 import org.jboss.migration.core.ProductInfo;
 import org.jboss.migration.core.Server;
 import org.jboss.migration.core.env.MigrationEnvironment;
+import org.jboss.migration.core.jboss.ModuleIdentifier;
 
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
@@ -38,7 +39,11 @@ public class WildFlyServerProvider8 extends AbstractServerProvider {
 
     @Override
     protected ProductInfo getProductInfo(Path baseDir, MigrationEnvironment migrationEnvironment) throws IllegalArgumentException, IOException {
-        final Path versionModuleMainDirPath = JBossServer.getModulesDir(baseDir).resolve("system").resolve("layers").resolve("base").resolve("org").resolve("jboss").resolve("as").resolve("version").resolve("main");
+        final JBossServer.Module module = new JBossServer.Modules(baseDir).getModule("org.jboss.as.version");
+        if (module == null) {
+            return null;
+        }
+        final Path versionModuleMainDirPath = new JBossServer.Modules(baseDir).getModuleDir(ModuleIdentifier.fromString("org.jboss.as.version"));
         if (!Files.isDirectory(versionModuleMainDirPath)) {
             return null;
         }

--- a/wildfly9-to-eap7/src/main/java/org/jboss/migration/wfly9/to/eap7/WildFly9ToEAP7_0ServerMigrationProvider.java
+++ b/wildfly9-to-eap7/src/main/java/org/jboss/migration/wfly9/to/eap7/WildFly9ToEAP7_0ServerMigrationProvider.java
@@ -17,6 +17,7 @@ package org.jboss.migration.wfly9.to.eap7;
 
 import org.jboss.migration.eap.EAPServerMigrationProvider7_0;
 import org.jboss.migration.wfly10.WildFlyServerMigration10;
+import org.jboss.migration.wfly10.config.task.module.ConfigurationModulesMigrationTaskFactory;
 import org.jboss.migration.wfly10.config.task.update.AddPrivateInterface;
 import org.jboss.migration.wfly10.config.task.update.AddSubsystemTasks;
 import org.jboss.migration.wfly10.config.task.update.MigrateCompatibleSecurityRealms;
@@ -40,6 +41,7 @@ public class WildFly9ToEAP7_0ServerMigrationProvider implements EAPServerMigrati
         return serverUpdateBuilders.serverUpdateBuilder()
                 .standaloneServer(serverUpdateBuilders.standaloneConfigurationBuilder()
                         .subtask(RemoveUnsupportedExtensionsAndSubsystems.INSTANCE)
+                        .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                         .subtask(WildFly9ToEAP7_0SubsystemUpdates.UNDERTOW)
                         .subtask(MigrateSubsystemTasks.MESSAGING)
                         .subtask(AddSubsystemTasks.BATCH_JBERET)
@@ -51,6 +53,7 @@ public class WildFly9ToEAP7_0ServerMigrationProvider implements EAPServerMigrati
                 .domain(serverUpdateBuilders.domainBuilder()
                         .domainConfigurations(serverUpdateBuilders.domainConfigurationBuilder()
                                 .subtask(RemoveUnsupportedExtensionsAndSubsystems.INSTANCE)
+                                .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                                 .subtask(WildFly9ToEAP7_0SubsystemUpdates.UNDERTOW)
                                 .subtask(MigrateSubsystemTasks.MESSAGING)
                                 .subtask(AddSubsystemTasks.BATCH_JBERET)
@@ -61,6 +64,7 @@ public class WildFly9ToEAP7_0ServerMigrationProvider implements EAPServerMigrati
                                 .subtask(RemoveDeployments.INSTANCE)
                         )
                         .hostConfigurations(serverUpdateBuilders.hostConfigurationBuilder()
+                                .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                                 .subtask(serverUpdateBuilders.hostBuilder()
                                         .subtask(UpdateUnsecureInterface.INSTANCE)
                                         .subtask(RemovePermgenAttributesFromJVMs.INSTANCE)

--- a/wildfly9-to-wildfly10/src/main/java/org/jboss/migration/wfly9/to/wfly10/WildFly9ToWildFly10_1ServerMigrationProvider.java
+++ b/wildfly9-to-wildfly10/src/main/java/org/jboss/migration/wfly9/to/wfly10/WildFly9ToWildFly10_1ServerMigrationProvider.java
@@ -16,6 +16,7 @@
 package org.jboss.migration.wfly9.to.wfly10;
 
 import org.jboss.migration.wfly10.WildFlyServerMigration10;
+import org.jboss.migration.wfly10.config.task.module.ConfigurationModulesMigrationTaskFactory;
 import org.jboss.migration.wfly10.config.task.update.AddApplicationRealmSSLServerIdentity;
 import org.jboss.migration.wfly10.config.task.update.AddPrivateInterface;
 import org.jboss.migration.wfly10.config.task.update.AddSocketBindingMulticastAddressExpressions;
@@ -43,6 +44,7 @@ public class WildFly9ToWildFly10_1ServerMigrationProvider implements WildFlyFull
         return serverUpdateBuilders.serverUpdateBuilder()
                 .standaloneServer(serverUpdateBuilders.standaloneConfigurationBuilder()
                         .subtask(RemoveUnsupportedExtensionsAndSubsystems.INSTANCE)
+                        .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                         .subtask(WildFly9ToWildFly10_1SubsystemUpdates.INFINISPAN)
                         .subtask(WildFly9ToWildFly10_1SubsystemUpdates.UNDERTOW)
                         .subtask(MigrateSubsystemTasks.MESSAGING)
@@ -57,6 +59,7 @@ public class WildFly9ToWildFly10_1ServerMigrationProvider implements WildFlyFull
                 .domain(serverUpdateBuilders.domainBuilder()
                         .domainConfigurations(serverUpdateBuilders.domainConfigurationBuilder()
                                 .subtask(RemoveUnsupportedExtensionsAndSubsystems.INSTANCE)
+                                .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                                 .subtask(WildFly9ToWildFly10_1SubsystemUpdates.INFINISPAN)
                                 .subtask(WildFly9ToWildFly10_1SubsystemUpdates.UNDERTOW)
                                 .subtask(MigrateSubsystemTasks.MESSAGING)
@@ -70,6 +73,7 @@ public class WildFly9ToWildFly10_1ServerMigrationProvider implements WildFlyFull
                                 .subtask(RemoveDeployments.INSTANCE)
                         )
                         .hostConfigurations(serverUpdateBuilders.hostConfigurationBuilder()
+                                .subtask(ConfigurationModulesMigrationTaskFactory.TASK_WITH_ALL_DEFAULT_MODULE_FINDERS)
                                 .subtask(serverUpdateBuilders.hostBuilder()
                                         .subtask(UpdateUnsecureInterface.INSTANCE)
                                         .subtask(RemovePermgenAttributesFromJVMs.INSTANCE)

--- a/wildfly9/src/main/java/org/jboss/migration/wfly9/WildFlyServer9.java
+++ b/wildfly9/src/main/java/org/jboss/migration/wfly9/WildFlyServer9.java
@@ -15,7 +15,7 @@
  */
 package org.jboss.migration.wfly9;
 
-import org.jboss.migration.core.JBossServer;
+import org.jboss.migration.core.jboss.JBossServer;
 import org.jboss.migration.core.ProductInfo;
 import org.jboss.migration.core.env.MigrationEnvironment;
 

--- a/wildfly9/src/main/java/org/jboss/migration/wfly9/WildFlyServerProvider9.java
+++ b/wildfly9/src/main/java/org/jboss/migration/wfly9/WildFlyServerProvider9.java
@@ -16,8 +16,8 @@
 package org.jboss.migration.wfly9;
 
 import org.jboss.migration.core.AbstractServerProvider;
-import org.jboss.migration.core.JBossServer;
-import org.jboss.migration.core.ManifestProductInfo;
+import org.jboss.migration.core.jboss.JBossServer;
+import org.jboss.migration.core.jboss.ManifestProductInfo;
 import org.jboss.migration.core.ProductInfo;
 import org.jboss.migration.core.Server;
 import org.jboss.migration.core.env.MigrationEnvironment;
@@ -32,7 +32,11 @@ import java.nio.file.Path;
 public class WildFlyServerProvider9 extends AbstractServerProvider {
 
     protected ProductInfo getProductInfo(Path baseDir, MigrationEnvironment migrationEnvironment) throws IllegalArgumentException, IOException {
-        final Path manifestPath = JBossServer.getModulesDir(baseDir).resolve("system").resolve("layers").resolve("base").resolve("org").resolve("jboss").resolve("as").resolve("product").resolve("wildfly-full").resolve("dir").resolve("META-INF").resolve("MANIFEST.MF");
+        final JBossServer.Module module = new JBossServer.Modules(baseDir).getModule("org.jboss.as.product:wildfly-full");
+        if (module == null) {
+            return null;
+        }
+        final Path manifestPath = module.getModuleDir().resolve("dir").resolve("META-INF").resolve("MANIFEST.MF");
         final ManifestProductInfo productInfo = ManifestProductInfo.from(manifestPath);
         return productInfo;
     }


### PR DESCRIPTION
… CMTOOL-107, CMTOOL-108: introducing the modules migration functionality, between jboss servers:
* task which migrates source server modules on demand by the user
* task which scans server configurations for module references, through pluggable module finders, and migrate referenced module from the source server, if missing in target server. 
* environment properties which the user may configure to indicate which modules should be included or excluded in the migration
* module finders for the following issues, regarding module references in configurations: CMTOOL-102, CMTOOL-103, CMTOOL-104, CMTOOL-105, CMTOOL-106, CMTOOL-107


