### PR TITLE
[CMTOOL-148] Fix system properties substitution for config.

### DIFF
--- a/cli/src/main/java/org/jboss/migration/cli/CommandLineServerMigration.java
+++ b/cli/src/main/java/org/jboss/migration/cli/CommandLineServerMigration.java
@@ -114,11 +114,12 @@ public class CommandLineServerMigration {
                     .run();
 
             // write reports
-            final String htmlReportFileName = userEnvironment.getPropertyAsString(EnvironmentProperties.REPORT_HTML_FILE_NAME);
-            final String xmlReportFileName = userEnvironment.getPropertyAsString(EnvironmentProperties.REPORT_XML_FILE_NAME);
+
+            final String htmlReportFileName = SystemEnvironment.INSTANCE.getPropertyAsString(EnvironmentProperties.REPORT_HTML_FILE_NAME);
+            final String xmlReportFileName = SystemEnvironment.INSTANCE.getPropertyAsString(EnvironmentProperties.REPORT_XML_FILE_NAME);
             if (htmlReportFileName != null) {
                 try {
-                    final String htmlReportTemplateFileName = userEnvironment.getPropertyAsString(EnvironmentProperties.REPORT_HTML_TEMPLATE_FILE_NAME, "migration-report-template.html");
+                    final String htmlReportTemplateFileName = SystemEnvironment.INSTANCE.getPropertyAsString(EnvironmentProperties.REPORT_HTML_TEMPLATE_FILE_NAME, "migration-report-template.html");
                     final Path htmlReportTemplatePath = configDirPath.resolve(htmlReportTemplateFileName);
                     HtmlReportWriter.INSTANCE.toPath(reportsDirPath.resolve(htmlReportFileName), migrationData, HtmlReportWriter.ReportTemplate.from(htmlReportTemplatePath));
                 } catch (Throwable e) {


### PR DESCRIPTION
https://issues.jboss.org/browse/CMTOOL-148
https://issues.jboss.org/browse/JBEAP-12901

Some system properties don't work properly as they still use default values defined in environment.properties. Get property from SystemEnvironment.INSTANCE to give it a chance to detect system properties passed through CLI parameters.