### PR TITLE
[CMTOOL-162] Server migrate tool returs 1 code on --help

### DIFF
--- a/cli/src/main/java/org/jboss/migration/cli/CommandLineServerMigration.java
+++ b/cli/src/main/java/org/jboss/migration/cli/CommandLineServerMigration.java
@@ -164,7 +164,7 @@ public class CommandLineServerMigration {
                 t.printStackTrace(STDERR);
             }
         } finally {
-            System.exit(1);
+            System.exit(t == null ? 0 : 1);
         }
     }
 


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/CMTOOL-162

Upstream not required