### PR TITLE
 CMTOOL-165: removes eap 6.4 subsystems from generic topic for unsupp…

### DIFF
--- a/docs/src/main/asciidoc/topics/EAP6.4toEAP7.0-ServerMigration-ManagedDomain-DomainConfiguration.adoc
+++ b/docs/src/main/asciidoc/topics/EAP6.4toEAP7.0-ServerMigration-ManagedDomain-DomainConfiguration.adoc
@@ -10,7 +10,7 @@ toc::[]
 
 :leveloffset: +1
 
-include::ServerMigration-ServerConfiguration-RemoveUnsupportedSubsystems.adoc[]
+include::EAP6.4toEAP7.0-ServerMigration-ServerConfiguration-RemoveUnsupportedSubsystems.adoc[]
 
 include::ServerMigration-ServerConfiguration-MigrateReferencedModules.adoc[]
 

--- a/docs/src/main/asciidoc/topics/EAP6.4toEAP7.0-ServerMigration-ServerConfiguration-RemoveUnsupportedSubsystems.adoc
+++ b/docs/src/main/asciidoc/topics/EAP6.4toEAP7.0-ServerMigration-ServerConfiguration-RemoveUnsupportedSubsystems.adoc
@@ -1,0 +1,25 @@
+= Remove Unsupported Subsystems
+
+All subsystems, and related extensions, which are not supported by {server-target-productName}, are automatically removed from a migrated configuration.
+
+The following {server-source-productName} subsystems are not supported by {server-target-productName}:
+
+|===
+|Subsystem Name |Configuration Namespace        |Extension Module
+
+|cmp            |urn:jboss:domain:cmp:*         |org.jboss.as.cmp
+|configadmin    |urn:jboss:domain:configadmin:* |org.jboss.as.configadmin
+|jaxr           |urn:jboss:domain:jaxr:*        |org.jboss.as.jaxr
+|osgi           |urn:jboss:domain:osgi:*        |org.jboss.as.osgi
+|threads        |urn:jboss:domain:threads:*     |org.jboss.as.threads
+|===
+
+NOTE: A subsystem installed in {server-source-productName} by the user, is also considered as unsupported by {server-target-productName}.
+
+The console logs the configuration namespaces, and extension modules, of unsupported subsystems removed from the server configuration being migrated:
+
+[source,options="nowrap"]
+----
+INFO  [ServerMigrationTask#5] Unsupported extensions removed: [org.jboss.as.jaxr, org.jboss.as.threads, org.jboss.as.cmp]
+INFO  [ServerMigrationTask#5] Unsupported subsystems removed: [urn:jboss:domain:jaxr:1.1, urn:jboss:domain:cmp:1.1, urn:jboss:domain:threads:1.1]
+----

--- a/docs/src/main/asciidoc/topics/EAP6.4toEAP7.0-ServerMigration-StandaloneServer-StandaloneServerConfiguration.adoc
+++ b/docs/src/main/asciidoc/topics/EAP6.4toEAP7.0-ServerMigration-StandaloneServer-StandaloneServerConfiguration.adoc
@@ -10,7 +10,7 @@ toc::[]
 
 :leveloffset: +1
 
-include::ServerMigration-ServerConfiguration-RemoveUnsupportedSubsystems.adoc[]
+include::EAP6.4toEAP7.0-ServerMigration-ServerConfiguration-RemoveUnsupportedSubsystems.adoc[]
 
 include::ServerMigration-ServerConfiguration-MigrateReferencedModules.adoc[]
 

--- a/docs/src/main/asciidoc/topics/EAP6.4toEAP7.1-ServerMigration-ManagedDomain-DomainConfiguration.adoc
+++ b/docs/src/main/asciidoc/topics/EAP6.4toEAP7.1-ServerMigration-ManagedDomain-DomainConfiguration.adoc
@@ -10,7 +10,7 @@ toc::[]
 
 :leveloffset: +1
 
-include::ServerMigration-ServerConfiguration-RemoveUnsupportedSubsystems.adoc[]
+include::EAP6.4toEAP7.1-ServerMigration-ServerConfiguration-RemoveUnsupportedSubsystems.adoc[]
 
 include::ServerMigration-ServerConfiguration-MigrateReferencedModules.adoc[]
 

--- a/docs/src/main/asciidoc/topics/EAP6.4toEAP7.1-ServerMigration-ServerConfiguration-RemoveUnsupportedSubsystems.adoc
+++ b/docs/src/main/asciidoc/topics/EAP6.4toEAP7.1-ServerMigration-ServerConfiguration-RemoveUnsupportedSubsystems.adoc
@@ -1,0 +1,1 @@
+include::EAP6.4toEAP7.0-ServerMigration-ServerConfiguration-RemoveUnsupportedSubsystems.adoc[]

--- a/docs/src/main/asciidoc/topics/EAP6.4toEAP7.1-ServerMigration-StandaloneServer-StandaloneServerConfiguration.adoc
+++ b/docs/src/main/asciidoc/topics/EAP6.4toEAP7.1-ServerMigration-StandaloneServer-StandaloneServerConfiguration.adoc
@@ -10,7 +10,7 @@ toc::[]
 
 :leveloffset: +1
 
-include::ServerMigration-ServerConfiguration-RemoveUnsupportedSubsystems.adoc[]
+include::EAP6.4toEAP7.1-ServerMigration-ServerConfiguration-RemoveUnsupportedSubsystems.adoc[]
 
 include::ServerMigration-ServerConfiguration-MigrateReferencedModules.adoc[]
 

--- a/docs/src/main/asciidoc/topics/ServerMigration-ServerConfiguration-RemoveUnsupportedSubsystems.adoc
+++ b/docs/src/main/asciidoc/topics/ServerMigration-ServerConfiguration-RemoveUnsupportedSubsystems.adoc
@@ -1,23 +1,13 @@
 = Remove Unsupported Subsystems
 
-The following {server-source-productName} subsystems are not supported by {server-target-productName}:
+All subsystems, and related extensions, which are not supported by {server-target-productName}, are automatically removed from a migrated configuration.
 
-|===
-|Subsystem Name |Configuration Namespace        |Extension Module
+NOTE: A subsystem installed in {server-source-productName} by the user, is also considered as unsupported by {server-target-productName}.
 
-|cmp            |urn:jboss:domain:cmp:*         |org.jboss.as.cmp
-|configadmin    |urn:jboss:domain:configadmin:* |org.jboss.as.configadmin
-|jaxr           |urn:jboss:domain:jaxr:*        |org.jboss.as.jaxr
-|osgi           |urn:jboss:domain:osgi:*        |org.jboss.as.osgi
-|threads        |urn:jboss:domain:threads:*     |org.jboss.as.threads
-|===
-
-All unsupported subsystems configurations and extensions are removed from migrated server configurations.
-
-The console logs the unsupported subsystem configurations and extensions as they are removed from a server configuration being migrated:
+The console logs the configuration namespaces, and extension modules, of unsupported subsystems removed from the server configuration being migrated:
 
 [source,options="nowrap"]
 ----
-INFO  [ServerMigrationTask#5] (main) Unsupported extensions removed: [org.jboss.as.jaxr, org.jboss.as.threads, org.jboss.as.cmp]
-INFO  [ServerMigrationTask#5] (main) Unsupported subsystems removed: [urn:jboss:domain:jaxr:1.1, urn:jboss:domain:cmp:1.1, urn:jboss:domain:threads:1.1]
+INFO  [ServerMigrationTask#5] Unsupported extensions removed: [com.example.extension]
+INFO  [ServerMigrationTask#5] Unsupported subsystems removed: [urn:example:domain:subsystem:1.0]
 ----


### PR DESCRIPTION
…orted subsystems removal, and introduces custom topic for server migration, from eap 6.4, user guides

JIRA: https://issues.jboss.org/projects/CMTOOL/issues/CMTOOL-165