### PR TITLE
CMTOOL-180: fixes typo in multicast address property names

### DIFF
--- a/wildfly10.1/src/main/java/org/jboss/migration/wfly10/config/task/update/AddSocketBindingMulticastAddressExpressions.java
+++ b/wildfly10.1/src/main/java/org/jboss/migration/wfly10/config/task/update/AddSocketBindingMulticastAddressExpressions.java
@@ -62,7 +62,7 @@ public class AddSocketBindingMulticastAddressExpressions<S> extends ManageableSe
     public static class AddSocketBindingMulticastAddressExpression<S> extends ManageableResourceLeafTask.Builder<S, SocketBindingResource> {
 
         protected AddSocketBindingMulticastAddressExpression(String resourceName) {
-            this(resourceName, "jboss."+resourceName+".multicast.adress");
+            this(resourceName, "jboss."+resourceName+".multicast.address");
         }
 
         protected AddSocketBindingMulticastAddressExpression(String resourceName, String propertyName) {


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/CMTOOL-180
Branch: 1.0.x