### PR TITLE
CMTOOL-199: updating elytron default config added to server configs m…

### DIFF
--- a/migrations/eap7.2/eap6.4/src/main/java/org/jboss/migration/eap6/to/eap7/EAP6_4ToEAP7_2ServerMigrationProvider.java
+++ b/migrations/eap7.2/eap6.4/src/main/java/org/jboss/migration/eap6/to/eap7/EAP6_4ToEAP7_2ServerMigrationProvider.java
@@ -18,13 +18,8 @@ package org.jboss.migration.eap6.to.eap7;
 import org.jboss.migration.eap.EAPServer6_4;
 import org.jboss.migration.eap.EAPServerMigrationProvider7_2;
 import org.jboss.migration.eap.task.hostexclude.EAP7_2AddHostExcludes;
-import org.jboss.migration.eap6.to.eap7.tasks.EAP6_4ToEAP7_2UpdateJGroupsSubsystem;
-import org.jboss.migration.wfly10.config.task.update.RemoveUnsupportedExtensions;
-import org.jboss.migration.wfly10.config.task.update.RemoveUnsupportedSubsystems;
-import org.jboss.migration.wfly11.task.subsystem.coremanagement.AddCoreManagementSubsystem;
-import org.jboss.migration.eap.task.subsystem.elytron.AddElytronSubsystem;
 import org.jboss.migration.eap.task.subsystem.web.EAP7_1MigrateWebSubsystem;
-import org.jboss.migration.wfly11.task.subsystem.logging.RemoveConsoleHandlerFromLoggingSubsystem;
+import org.jboss.migration.eap6.to.eap7.tasks.EAP6_4ToEAP7_2UpdateJGroupsSubsystem;
 import org.jboss.migration.eap6.to.eap7.tasks.AddSocketBindingPortExpressions;
 import org.jboss.migration.eap6.to.eap7.tasks.EAP6_4ToEAP7_2UpdateEESubsystem;
 import org.jboss.migration.eap6.to.eap7.tasks.EAP6_4ToEAP7_2UpdateEJB3Subsystem;
@@ -50,9 +45,15 @@ import org.jboss.migration.wfly10.config.task.update.MigrateCompatibleSecurityRe
 import org.jboss.migration.wfly10.config.task.update.MigrateDeployments;
 import org.jboss.migration.wfly10.config.task.update.RemovePermgenAttributesFromJVMConfigs;
 import org.jboss.migration.wfly10.config.task.update.RemoveUnsecureInterface;
+import org.jboss.migration.wfly10.config.task.update.RemoveUnsupportedExtensions;
+import org.jboss.migration.wfly10.config.task.update.RemoveUnsupportedSubsystems;
 import org.jboss.migration.wfly10.config.task.update.ServerUpdate;
 import org.jboss.migration.wfly10.config.task.update.UpdateUnsecureInterface;
 import org.jboss.migration.wfly10.config.task.update.AddLoadBalancerProfile;
+import org.jboss.migration.wfly11.task.subsystem.coremanagement.AddCoreManagementSubsystem;
+import org.jboss.migration.wfly11.task.subsystem.logging.RemoveConsoleHandlerFromLoggingSubsystem;
+import org.jboss.migration.wfly13.task.subsystem.elytron.WildFly13_0AddElytronSubsystem;
+
 
 /**
  * Server migration, from EAP 6.4 to EAP 7.2.
@@ -69,7 +70,7 @@ public class EAP6_4ToEAP7_2ServerMigrationProvider implements EAPServerMigration
                         .subtask(new MigrateReferencedModules<>())
                         .subtask(new MigrateReferencedPaths<>())
                         .subtask(new MigrateJacorbSubsystem<>())
-                        .subtask(new AddElytronSubsystem<>())
+                        .subtask(new WildFly13_0AddElytronSubsystem<>())
                         .subtask(new EAP7_1MigrateWebSubsystem<>())
                         .subtask(new EAP6_4ToEAP7_2UpdateUndertowSubsystem<>())
                         .subtask(new MigrateMessagingSubsystem<>())
@@ -98,7 +99,7 @@ public class EAP6_4ToEAP7_2ServerMigrationProvider implements EAPServerMigration
                                 .subtask(new MigrateReferencedModules<>())
                                 .subtask(new MigrateReferencedPaths<>())
                                 .subtask(new MigrateJacorbSubsystem<>())
-                                .subtask(new AddElytronSubsystem<>())
+                                .subtask(new WildFly13_0AddElytronSubsystem<>())
                                 .subtask(new EAP7_1MigrateWebSubsystem<>())
                                 .subtask(new EAP6_4ToEAP7_2UpdateUndertowSubsystem<>())
                                 .subtask(new MigrateMessagingSubsystem<>())
@@ -127,7 +128,7 @@ public class EAP6_4ToEAP7_2ServerMigrationProvider implements EAPServerMigration
                                 .subtask(new MigrateReferencedPaths<>())
                                 .subtask(serverUpdateBuilders.hostBuilder()
                                         .subtask(new AddCoreManagementSubsystem<>())
-                                        .subtask(new AddElytronSubsystem<>())
+                                        .subtask(new WildFly13_0AddElytronSubsystem<>())
                                         .subtask(new AddJmxSubsystemToHosts<>())
                                         .subtask(new RemoveUnsecureInterface<>())
                                         .subtask(new SetupHttpUpgradeManagement<>())

--- a/migrations/eap7.2/eap7.0/src/main/java/org/jboss/migration/eap7/to/eap7/EAP7_0ToEAP7_2ServerMigrationProvider.java
+++ b/migrations/eap7.2/eap7.0/src/main/java/org/jboss/migration/eap7/to/eap7/EAP7_0ToEAP7_2ServerMigrationProvider.java
@@ -21,9 +21,6 @@ import org.jboss.migration.eap.EAPServerMigrationProvider7_2;
 import org.jboss.migration.eap.task.hostexclude.EAP7_2AddHostExcludes;
 import org.jboss.migration.wfly10.config.task.update.RemoveUnsupportedExtensions;
 import org.jboss.migration.wfly10.config.task.update.RemoveUnsupportedSubsystems;
-import org.jboss.migration.wfly11.task.subsystem.coremanagement.AddCoreManagementSubsystem;
-import org.jboss.migration.eap.task.subsystem.elytron.AddElytronSubsystem;
-import org.jboss.migration.wfly11.task.subsystem.logging.RemoveConsoleHandlerFromLoggingSubsystem;
 import org.jboss.migration.wfly10.WildFlyServer10;
 import org.jboss.migration.wfly10.WildFlyServerMigration10;
 import org.jboss.migration.wfly10.config.task.module.MigrateReferencedModules;
@@ -34,6 +31,9 @@ import org.jboss.migration.wfly10.config.task.update.MigrateCompatibleSecurityRe
 import org.jboss.migration.wfly10.config.task.update.MigrateDeployments;
 import org.jboss.migration.wfly10.config.task.update.ServerUpdate;
 import org.jboss.migration.wfly10.config.task.update.AddLoadBalancerProfile;
+import org.jboss.migration.wfly11.task.subsystem.coremanagement.AddCoreManagementSubsystem;
+import org.jboss.migration.wfly11.task.subsystem.logging.RemoveConsoleHandlerFromLoggingSubsystem;
+import org.jboss.migration.wfly13.task.subsystem.elytron.WildFly13_0AddElytronSubsystem;
 
 /**
  * Server migration, from EAP 7.0 to EAP 7.2.
@@ -55,7 +55,7 @@ public class EAP7_0ToEAP7_2ServerMigrationProvider implements EAPServerMigration
                                 .subtask(new EAP7_0ToEAP7_2UpdateUndertowSubsystem<>())
                                 .subtask(new EAP7_0ToEAP7_2UpdateJGroupsSubsystem<>())
                                 .subtask(new AddCoreManagementSubsystem<>())
-                                .subtask(new AddElytronSubsystem<>())
+                                .subtask(new WildFly13_0AddElytronSubsystem<>())
                                 .subtask(new AddSocketBindingMulticastAddressExpressions<>())
                                 .subtask(new MigrateCompatibleSecurityRealms<>())
                                 .subtask(new AddApplicationRealmSSLServerIdentity<>())
@@ -70,7 +70,7 @@ public class EAP7_0ToEAP7_2ServerMigrationProvider implements EAPServerMigration
                                 .subtask(new EAP7_0ToEAP7_2UpdateUndertowSubsystem<>())
                                 .subtask(new EAP7_0ToEAP7_2UpdateJGroupsSubsystem<>())
                                 .subtask(new AddCoreManagementSubsystem<>())
-                                .subtask(new AddElytronSubsystem<>())
+                                .subtask(new WildFly13_0AddElytronSubsystem<>())
                                 .subtask(new AddSocketBindingMulticastAddressExpressions<>())
                                 .subtask(new AddLoadBalancerProfile<>())
                                 .subtask(new EAP7_2AddHostExcludes<>())
@@ -81,7 +81,7 @@ public class EAP7_0ToEAP7_2ServerMigrationProvider implements EAPServerMigration
                                 .subtask(new MigrateReferencedPaths<>())
                                 .subtask(serverUpdateBuilders.hostBuilder()
                                         .subtask(new AddCoreManagementSubsystem<>())
-                                        .subtask(new AddElytronSubsystem<>())
+                                        .subtask(new WildFly13_0AddElytronSubsystem<>())
                                         .subtask(new MigrateCompatibleSecurityRealms<>())
                                         .subtask(new AddApplicationRealmSSLServerIdentity<>()))))
                 .build();

--- a/migrations/eap7.2/wildfly10.0/src/main/java/org/jboss/migration/wfly10/to/eap7/WildFly10_0ToEAP7_2ServerMigrationProvider.java
+++ b/migrations/eap7.2/wildfly10.0/src/main/java/org/jboss/migration/wfly10/to/eap7/WildFly10_0ToEAP7_2ServerMigrationProvider.java
@@ -32,8 +32,8 @@ import org.jboss.migration.wfly10.config.task.update.RemoveUnsupportedSubsystems
 import org.jboss.migration.wfly10.config.task.update.ServerUpdate;
 import org.jboss.migration.wfly10.dist.full.WildFlyFullServer10_0;
 import org.jboss.migration.wfly11.task.subsystem.coremanagement.AddCoreManagementSubsystem;
-import org.jboss.migration.wfly11.task.subsystem.elytron.AddElytronSubsystem;
 import org.jboss.migration.wfly11.task.subsystem.logging.RemoveConsoleHandlerFromLoggingSubsystem;
+import org.jboss.migration.wfly13.task.subsystem.elytron.WildFly13_0AddElytronSubsystem;
 
 /**
  * Server migration to EAP 7.2, from WFLY 10.0.
@@ -54,7 +54,7 @@ public class WildFly10_0ToEAP7_2ServerMigrationProvider implements EAPServerMigr
                         .subtask(new WildFly10_0ToEAP7_2UpdateUndertowSubsystem<>())
                         .subtask(new WildFly10_0ToEAP7_2UpdateJGroupsSubsystem<>())
                         .subtask(new AddCoreManagementSubsystem<>())
-                        .subtask(new AddElytronSubsystem<>())
+                        .subtask(new WildFly13_0AddElytronSubsystem<>())
                         .subtask(new AddSocketBindingMulticastAddressExpressions<>())
                         .subtask(new MigrateCompatibleSecurityRealms<>())
                         .subtask(new AddApplicationRealmSSLServerIdentity<>())
@@ -69,7 +69,7 @@ public class WildFly10_0ToEAP7_2ServerMigrationProvider implements EAPServerMigr
                                 .subtask(new WildFly10_0ToEAP7_2UpdateUndertowSubsystem<>())
                                 .subtask(new WildFly10_0ToEAP7_2UpdateJGroupsSubsystem<>())
                                 .subtask(new AddCoreManagementSubsystem<>())
-                                .subtask(new AddElytronSubsystem<>())
+                                .subtask(new WildFly13_0AddElytronSubsystem<>())
                                 .subtask(new AddSocketBindingMulticastAddressExpressions<>())
                                 .subtask(new AddLoadBalancerProfile<>())
                                 .subtask(new EAP7_2AddHostExcludes<>())
@@ -80,7 +80,7 @@ public class WildFly10_0ToEAP7_2ServerMigrationProvider implements EAPServerMigr
                                 .subtask(new MigrateReferencedPaths<>())
                                 .subtask(serverUpdateBuilders.hostBuilder()
                                         .subtask(new AddCoreManagementSubsystem<>())
-                                        .subtask(new AddElytronSubsystem<>())
+                                        .subtask(new WildFly13_0AddElytronSubsystem<>())
                                         .subtask(new MigrateCompatibleSecurityRealms<>())
                                         .subtask(new AddApplicationRealmSSLServerIdentity<>()))))
                 .build();

--- a/migrations/eap7.2/wildfly10.1/src/main/java/org/jboss/migration/wfly10/to/eap7/WildFly10_1ToEAP7_2ServerMigrationProvider.java
+++ b/migrations/eap7.2/wildfly10.1/src/main/java/org/jboss/migration/wfly10/to/eap7/WildFly10_1ToEAP7_2ServerMigrationProvider.java
@@ -29,8 +29,9 @@ import org.jboss.migration.wfly10.config.task.update.RemoveUnsupportedSubsystems
 import org.jboss.migration.wfly10.config.task.update.ServerUpdate;
 import org.jboss.migration.wfly10.dist.full.WildFlyFullServer10_1;
 import org.jboss.migration.wfly11.task.subsystem.coremanagement.AddCoreManagementSubsystem;
-import org.jboss.migration.wfly11.task.subsystem.elytron.AddElytronSubsystem;
 import org.jboss.migration.wfly11.task.subsystem.logging.RemoveConsoleHandlerFromLoggingSubsystem;
+import org.jboss.migration.wfly13.task.subsystem.elytron.WildFly13_0AddElytronSubsystem;
+
 /**
  * Server migration to EAP 7.2, from WFLY 10.1.
  * @author emmartins
@@ -50,7 +51,7 @@ public class WildFly10_1ToEAP7_2ServerMigrationProvider implements EAPServerMigr
                         .subtask(new WildFly10_1ToEAP7_2UpdateUndertowSubsystem<>())
                         .subtask(new WildFly10_1ToEAP7_2UpdateJGroupsSubsystem<>())
                         .subtask(new AddCoreManagementSubsystem<>())
-                        .subtask(new AddElytronSubsystem<>())
+                        .subtask(new WildFly13_0AddElytronSubsystem<>())
                         .subtask(new MigrateCompatibleSecurityRealms<>())
                         .subtask(new MigrateDeployments<>()))
                 .domain(serverUpdateBuilders.domainBuilder()
@@ -63,7 +64,7 @@ public class WildFly10_1ToEAP7_2ServerMigrationProvider implements EAPServerMigr
                                 .subtask(new WildFly10_1ToEAP7_2UpdateUndertowSubsystem<>())
                                 .subtask(new WildFly10_1ToEAP7_2UpdateJGroupsSubsystem<>())
                                 .subtask(new AddCoreManagementSubsystem<>())
-                                .subtask(new AddElytronSubsystem<>())
+                                .subtask(new WildFly13_0AddElytronSubsystem<>())
                                 .subtask(new EAP7_2AddHostExcludes<>())
                                 .subtask(new RemoveConsoleHandlerFromLoggingSubsystem<>())
                                 .subtask(new MigrateDeployments<>()))
@@ -72,7 +73,7 @@ public class WildFly10_1ToEAP7_2ServerMigrationProvider implements EAPServerMigr
                                 .subtask(new MigrateReferencedPaths<>())
                                 .subtask(serverUpdateBuilders.hostBuilder()
                                         .subtask(new AddCoreManagementSubsystem<>())
-                                        .subtask(new AddElytronSubsystem<>())
+                                        .subtask(new WildFly13_0AddElytronSubsystem<>())
                                         .subtask(new MigrateCompatibleSecurityRealms<>()))))
                 .build();
     }

--- a/migrations/eap7.2/wildfly8.2/src/main/java/org/jboss/migration/wfly8/to/eap7/WildFly8ToEAP7_2ServerMigrationProvider.java
+++ b/migrations/eap7.2/wildfly8.2/src/main/java/org/jboss/migration/wfly8/to/eap7/WildFly8ToEAP7_2ServerMigrationProvider.java
@@ -19,9 +19,6 @@ import org.jboss.migration.eap.EAPServerMigrationProvider7_2;
 import org.jboss.migration.eap.task.hostexclude.EAP7_2AddHostExcludes;
 import org.jboss.migration.wfly10.config.task.update.RemoveUnsupportedExtensions;
 import org.jboss.migration.wfly10.config.task.update.RemoveUnsupportedSubsystems;
-import org.jboss.migration.wfly11.task.subsystem.coremanagement.AddCoreManagementSubsystem;
-import org.jboss.migration.wfly11.task.subsystem.elytron.AddElytronSubsystem;
-import org.jboss.migration.wfly11.task.subsystem.logging.RemoveConsoleHandlerFromLoggingSubsystem;
 import org.jboss.migration.wfly10.WildFlyServerMigration10;
 import org.jboss.migration.wfly10.config.task.module.MigrateReferencedModules;
 import org.jboss.migration.wfly10.config.task.paths.MigrateReferencedPaths;
@@ -42,6 +39,9 @@ import org.jboss.migration.wfly10.config.task.update.RemoveUnsecureInterface;
 import org.jboss.migration.wfly10.config.task.update.ServerUpdate;
 import org.jboss.migration.wfly10.config.task.update.UpdateUnsecureInterface;
 import org.jboss.migration.wfly10.config.task.update.AddLoadBalancerProfile;
+import org.jboss.migration.wfly11.task.subsystem.coremanagement.AddCoreManagementSubsystem;
+import org.jboss.migration.wfly11.task.subsystem.logging.RemoveConsoleHandlerFromLoggingSubsystem;
+import org.jboss.migration.wfly13.task.subsystem.elytron.WildFly13_0AddElytronSubsystem;
 import org.jboss.migration.wfly8.WildFlyServer8;
 
 /**
@@ -66,7 +66,7 @@ public class WildFly8ToEAP7_2ServerMigrationProvider implements EAPServerMigrati
                         .subtask(new MigrateMessagingSubsystem<>())
                         .subtask(new AddBatchJBeretSubsystem<>())
                         .subtask(new AddCoreManagementSubsystem<>())
-                        .subtask(new AddElytronSubsystem<>())
+                        .subtask(new WildFly13_0AddElytronSubsystem<>())
                         .subtask(new AddRequestControllerSubsystem<>())
                         .subtask(new AddSecurityManagerSubsystem<>())
                         .subtask(new AddSingletonSubsystem<>())
@@ -88,7 +88,7 @@ public class WildFly8ToEAP7_2ServerMigrationProvider implements EAPServerMigrati
                                 .subtask(new MigrateMessagingSubsystem<>())
                                 .subtask(new AddBatchJBeretSubsystem<>())
                                 .subtask(new AddCoreManagementSubsystem<>())
-                                .subtask(new AddElytronSubsystem<>())
+                                .subtask(new WildFly13_0AddElytronSubsystem<>())
                                 .subtask(new AddRequestControllerSubsystem<>())
                                 .subtask(new AddSecurityManagerSubsystem<>())
                                 .subtask(new AddSingletonSubsystem<>())
@@ -105,7 +105,7 @@ public class WildFly8ToEAP7_2ServerMigrationProvider implements EAPServerMigrati
                                 .subtask(new MigrateReferencedPaths<>())
                                 .subtask(serverUpdateBuilders.hostBuilder()
                                         .subtask(new AddCoreManagementSubsystem<>())
-                                        .subtask(new AddElytronSubsystem<>())
+                                        .subtask(new WildFly13_0AddElytronSubsystem<>())
                                         .subtask(new AddJmxSubsystemToHosts<>())
                                         .subtask(new RemoveUnsecureInterface<>())
                                         .subtask(new RemovePermgenAttributesFromJVMConfigs<>())

--- a/migrations/eap7.2/wildfly9.0/src/main/java/org/jboss/migration/wfly9/to/eap7/WildFly9ToEAP7_2ServerMigrationProvider.java
+++ b/migrations/eap7.2/wildfly9.0/src/main/java/org/jboss/migration/wfly9/to/eap7/WildFly9ToEAP7_2ServerMigrationProvider.java
@@ -36,8 +36,8 @@ import org.jboss.migration.wfly10.config.task.update.RemoveUnsupportedSubsystems
 import org.jboss.migration.wfly10.config.task.update.ServerUpdate;
 import org.jboss.migration.wfly10.config.task.update.UpdateUnsecureInterface;
 import org.jboss.migration.wfly11.task.subsystem.coremanagement.AddCoreManagementSubsystem;
-import org.jboss.migration.wfly11.task.subsystem.elytron.AddElytronSubsystem;
 import org.jboss.migration.wfly11.task.subsystem.logging.RemoveConsoleHandlerFromLoggingSubsystem;
+import org.jboss.migration.wfly13.task.subsystem.elytron.WildFly13_0AddElytronSubsystem;
 import org.jboss.migration.wfly9.WildFlyServer9;
 
 /**
@@ -61,7 +61,7 @@ public class WildFly9ToEAP7_2ServerMigrationProvider implements EAPServerMigrati
                         .subtask(new MigrateMessagingSubsystem<>())
                         .subtask(new AddBatchJBeretSubsystem<>())
                         .subtask(new AddCoreManagementSubsystem<>())
-                        .subtask(new AddElytronSubsystem<>())
+                        .subtask(new WildFly13_0AddElytronSubsystem<>())
                         .subtask(new AddSingletonSubsystem<>())
                         .subtask(new AddPrivateInterface<>())
                         .subtask(new AddSocketBindingMulticastAddressExpressions<>())
@@ -80,7 +80,7 @@ public class WildFly9ToEAP7_2ServerMigrationProvider implements EAPServerMigrati
                                 .subtask(new MigrateMessagingSubsystem<>())
                                 .subtask(new AddBatchJBeretSubsystem<>())
                                 .subtask(new AddCoreManagementSubsystem<>())
-                                .subtask(new AddElytronSubsystem<>())
+                                .subtask(new WildFly13_0AddElytronSubsystem<>())
                                 .subtask(new AddSingletonSubsystem<>())
                                 .subtask(new UpdateUnsecureInterface<>())
                                 .subtask(new AddPrivateInterface<>())
@@ -95,7 +95,7 @@ public class WildFly9ToEAP7_2ServerMigrationProvider implements EAPServerMigrati
                                 .subtask(new MigrateReferencedPaths<>())
                                 .subtask(serverUpdateBuilders.hostBuilder()
                                         .subtask(new AddCoreManagementSubsystem<>())
-                                        .subtask(new AddElytronSubsystem<>())
+                                        .subtask(new WildFly13_0AddElytronSubsystem<>())
                                         .subtask(new RemoveUnsecureInterface<>())
                                         .subtask(new RemovePermgenAttributesFromJVMConfigs<>())
                                         .subtask(new MigrateCompatibleSecurityRealms<>())


### PR DESCRIPTION
…igrated to eap 7.2
JIRA: https://issues.jboss.org/projects/CMTOOL/issues/CMTOOL-199
Please note that this only updates tasks which add the configs, it does not updates EAP 7.1 configs to match EAP 7.2. The reason for not updating EAP 7.1 configs too is such configs are effectively the same, the permissions are the same, JBoss EAP 7.2 simply uses permission sets instead of list such permissions each time "used", as in JBoss EAP 7.1. 