### PR TITLE
CMTOOL-209: Add Widfly13 server module eap7.2 feature-pack dependencies

### DIFF
--- a/dist/feature-packs/eap7.2/pom.xml
+++ b/dist/feature-packs/eap7.2/pom.xml
@@ -335,6 +335,17 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jboss-server-migration-wildfly13.0-server</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/dist/feature-packs/eap7.2/src/main/resources/modules/system/layers/base/org/jboss/migration/cli/main/module.xml
+++ b/dist/feature-packs/eap7.2/src/main/resources/modules/system/layers/base/org/jboss/migration/cli/main/module.xml
@@ -52,6 +52,7 @@
         <artifact name="${org.jboss.migration:jboss-server-migration-wildfly11.0}"/>
         <artifact name="${org.jboss.migration:jboss-server-migration-wildfly11.0-to-eap7.2}"/>
         <artifact name="${org.jboss.migration:jboss-server-migration-wildfly12.0}"/>
+        <artifact name="${org.jboss.migration:jboss-server-migration-wildfly13.0-server}"/>
     </resources>
 
     <dependencies>


### PR DESCRIPTION
Widfly13 server module should be among eap7.2 feature-pack dependencies as EAP 7.2 server now depends on it https://github.com/wildfly/wildfly-server-migration/commit/4b8d86b60e2e355025121b17e5dcd981d0692117