### PR TITLE
JBEAP-15064: Remove core license

### DIFF
--- a/eap7.1-feature-pack/pom.xml
+++ b/eap7.1-feature-pack/pom.xml
@@ -359,6 +359,7 @@
                                     <sortByGroupIdAndArtifactId>true</sortByGroupIdAndArtifactId>
                                     <licensesOutputDirectory>${license.directory}</licensesOutputDirectory>
                                     <licensesOutputFile>${license.directory}/migration-feature-pack-licenses.xml</licensesOutputFile>
+                                    <excludedArtifacts>wildfly-core-feature-pack</excludedArtifacts>
                                     <excludedScopes>system,provided</excludedScopes>
                                 </configuration>
                             </execution>

--- a/eap7.1-feature-pack/src/license/migration-feature-pack-licenses.xml
+++ b/eap7.1-feature-pack/src/license/migration-feature-pack-licenses.xml
@@ -2,18 +2,6 @@
 <licenseSummary>
   <dependencies>
     <dependency>
-      <groupId>org.wildfly.core</groupId>
-      <artifactId>wildfly-core-feature-pack</artifactId>
-      <type>zip</type>
-      <licenses>
-        <license>
-          <name>GNU Lesser General Public License v2.1 only</name>
-          <url>http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</url>
-          <distribution>repo</distribution>
-        </license>
-      </licenses>
-    </dependency>
-    <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
       <licenses>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBEAP-15064

Upstream not required.