### PR TITLE
Fixes to managed domain migration from 6.4 to 7.2, transactions subsubsystem is plural.

### DIFF
--- a/docs/user-guides/migrations/eap7.2/eap6.4/src/main/asciidoc/topics/EAP6.4toEAP7.2-ServerMigration-ManagedDomain.adoc
+++ b/docs/user-guides/migrations/eap7.2/eap6.4/src/main/asciidoc/topics/EAP6.4toEAP7.2-ServerMigration-ManagedDomain.adoc
@@ -6,9 +6,9 @@ include::ServerMigration-ManagedDomain.adoc[]
 // include configuration
 :leveloffset: +1
 
-include::ManagedDomain-DomainConfiguration.adoc[]
+include::EAP6.4toEAP7.2-ServerMigration-ManagedDomain-DomainConfiguration.adoc[]
 
-include::ManagedDomain-HostConfiguration.adoc[]
+include::EAP6.4toEAP7.2-ServerMigration-ManagedDomain-HostConfiguration.adoc[]
 
 :leveloffset: -1
 

--- a/docs/user-guides/migrations/includes/src/main/resources/topics/ServerMigration-ServerConfiguration-Subsystem-Update-transactions.adoc
+++ b/docs/user-guides/migrations/includes/src/main/resources/topics/ServerMigration-ServerConfiguration-Subsystem-Update-transactions.adoc
@@ -1,4 +1,4 @@
-= Update the transaction Subsystem
+= Update the transactions Subsystem
 
 The JBoss Server Migration Tool updates the *transactions* subsystem with the configuration changes required by the {server-target-productName} server.
 


### PR DESCRIPTION
@emmartins : The doc for migration from 6.4 to 7.2 was truncated because of a build error. The included topics for the managed domain migration were missing the prefix 'EAP6.4toEAP7.2-ServerMigration-'.

I also fixed the 'transactions' subsystem.