### PR TITLE
[CMTOOL-320] migrated legacy picketlink-federation subsystem to new k…

### DIFF
--- a/core/src/main/java/org/jboss/migration/core/jboss/JBossExtensionNames.java
+++ b/core/src/main/java/org/jboss/migration/core/jboss/JBossExtensionNames.java
@@ -68,6 +68,7 @@ public interface JBossExtensionNames {
     String NAMING = "org.jboss.as.naming";
     String OPENTELEMETRY = "org.wildfly.extension.opentelemetry";
     String OSGI = "org.jboss.as.osgi";
+    String PICKETLINK = "org.wildfly.extension.picketlink";
     String POJO = "org.jboss.as.pojo";
     String REMOTING = "org.jboss.as.remoting";
     String REQUEST_CONTROLLER = "org.wildfly.extension.request-controller";

--- a/core/src/main/java/org/jboss/migration/core/jboss/JBossExtensions.java
+++ b/core/src/main/java/org/jboss/migration/core/jboss/JBossExtensions.java
@@ -263,6 +263,11 @@ public interface JBossExtensions {
             .subsystem(JBossSubsystemNames.OSGI)
             .build();
 
+    Extension PICKETLINK = Extension.builder()
+            .module(JBossExtensionNames.PICKETLINK)
+            .subsystem(JBossSubsystemNames.PICKETLINK_FEDERATION)
+            .build();
+
     Extension POJO = Extension.builder()
             .module(JBossExtensionNames.POJO)
             .subsystem(JBossSubsystemNames.POJO)

--- a/core/src/main/java/org/jboss/migration/core/jboss/JBossSubsystemNames.java
+++ b/core/src/main/java/org/jboss/migration/core/jboss/JBossSubsystemNames.java
@@ -70,6 +70,7 @@ public interface JBossSubsystemNames {
     String NAMING = "naming";
     String OPENTELEMETRY = "opentelemetry";
     String OSGI = "osgi";
+    String PICKETLINK_FEDERATION = "picketlink-federation";
     String POJO = "pojo";
     String REMOTING = "remoting";
     String REQUEST_CONTROLLER = "request-controller";

--- a/migrations/eap8.0/eap7.0/src/main/java/org/jboss/migration/eap7/to/eap8/EAP7_0ToEAP8_0ServerMigrationProvider.java
+++ b/migrations/eap8.0/eap7.0/src/main/java/org/jboss/migration/eap7/to/eap8/EAP7_0ToEAP8_0ServerMigrationProvider.java
@@ -23,6 +23,7 @@ import org.jboss.migration.eap.task.subsystem.metrics.EAP8_0AddMetricsSubsystem;
 import org.jboss.migration.wfly.task.paths.WildFly26_0MigrateReferencedPaths;
 import org.jboss.migration.wfly.task.security.LegacySecurityConfigurationMigration;
 import org.jboss.migration.wfly.task.subsystem.health.WildFly26_0AddHealthSubsystem;
+import org.jboss.migration.wfly.task.subsystem.picketlink.MigratePicketLinkSubsystem;
 import org.jboss.migration.wfly.task.xml.WildFly26_0MigrateVault;
 import org.jboss.migration.wfly.task.xml.WildFly27_0MigrateJBossDomainProperties;
 import org.jboss.migration.wfly10.WildFlyServer10;
@@ -71,6 +72,7 @@ public class EAP7_0ToEAP8_0ServerMigrationProvider implements EAPServerMigration
                         .subtask(new WildFly26_0AddHealthSubsystem<>())
                         .subtask(new EAP8_0AddMetricsSubsystem<>())
                         .subtask(new AddSocketBindingMulticastAddressExpressions<>())
+                        .subtask(new MigratePicketLinkSubsystem<>())
                         .subtask(new MigrateDeployments<>())
                 )
                 .domain(serverUpdateBuilders.domainBuilder()
@@ -95,6 +97,7 @@ public class EAP7_0ToEAP8_0ServerMigrationProvider implements EAPServerMigration
                                 .subtask(legacySecurityConfigurationMigration.getEnsureBasicElytronSubsystem())
                                 .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityRealmsToElytron())
                                 .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityDomainsToElytron())
+                                .subtask(new MigratePicketLinkSubsystem<>())
                                 .subtask(new MigrateDeployments<>())
                         )
                         .hostConfigurations(serverUpdateBuilders.hostConfigurationBuilder()

--- a/migrations/eap8.0/eap7.1/src/main/java/org/jboss/migration/eap7/to/eap8/EAP7_1ToEAP8_0ServerMigrationProvider.java
+++ b/migrations/eap8.0/eap7.1/src/main/java/org/jboss/migration/eap7/to/eap8/EAP7_1ToEAP8_0ServerMigrationProvider.java
@@ -23,6 +23,7 @@ import org.jboss.migration.eap.task.subsystem.metrics.EAP8_0AddMetricsSubsystem;
 import org.jboss.migration.wfly.task.paths.WildFly26_0MigrateReferencedPaths;
 import org.jboss.migration.wfly.task.security.LegacySecurityConfigurationMigration;
 import org.jboss.migration.wfly.task.subsystem.health.WildFly26_0AddHealthSubsystem;
+import org.jboss.migration.wfly.task.subsystem.picketlink.MigratePicketLinkSubsystem;
 import org.jboss.migration.wfly.task.xml.WildFly26_0MigrateVault;
 import org.jboss.migration.wfly.task.xml.WildFly27_0MigrateJBossDomainProperties;
 import org.jboss.migration.wfly10.WildFlyServer10;
@@ -67,6 +68,7 @@ public class EAP7_1ToEAP8_0ServerMigrationProvider implements EAPServerMigration
                                 .subtask(new AddEESecuritySubsystem<>())
                                 .subtask(new WildFly26_0AddHealthSubsystem<>())
                                 .subtask(new EAP8_0AddMetricsSubsystem<>())
+                                .subtask(new MigratePicketLinkSubsystem<>())
                                 .subtask(new MigrateDeployments<>())
                 )
                 .domain(serverUpdateBuilders.domainBuilder()
@@ -88,6 +90,7 @@ public class EAP7_1ToEAP8_0ServerMigrationProvider implements EAPServerMigration
                                 .subtask(legacySecurityConfigurationMigration.getEnsureBasicElytronSubsystem())
                                 .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityRealmsToElytron())
                                 .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityDomainsToElytron())
+                                .subtask(new MigratePicketLinkSubsystem<>())
                                 .subtask(new MigrateDeployments<>())
                         )
                         .hostConfigurations(serverUpdateBuilders.hostConfigurationBuilder()

--- a/migrations/eap8.0/eap7.2/src/main/java/org/jboss/migration/eap7/to/eap8/EAP7_2ToEAP8_0ServerMigrationProvider.java
+++ b/migrations/eap8.0/eap7.2/src/main/java/org/jboss/migration/eap7/to/eap8/EAP7_2ToEAP8_0ServerMigrationProvider.java
@@ -23,6 +23,7 @@ import org.jboss.migration.eap.task.subsystem.metrics.EAP8_0AddMetricsSubsystem;
 import org.jboss.migration.wfly.task.paths.WildFly26_0MigrateReferencedPaths;
 import org.jboss.migration.wfly.task.security.LegacySecurityConfigurationMigration;
 import org.jboss.migration.wfly.task.subsystem.health.WildFly26_0AddHealthSubsystem;
+import org.jboss.migration.wfly.task.subsystem.picketlink.MigratePicketLinkSubsystem;
 import org.jboss.migration.wfly.task.update.WildFly22_0UpdateInfinispanSubsystem;
 import org.jboss.migration.wfly.task.xml.WildFly26_0MigrateVault;
 import org.jboss.migration.wfly.task.xml.WildFly27_0MigrateJBossDomainProperties;
@@ -61,6 +62,7 @@ public class EAP7_2ToEAP8_0ServerMigrationProvider implements EAPServerMigration
                                 .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityDomainsToElytron())
                                 .subtask(new WildFly26_0AddHealthSubsystem<>())
                                 .subtask(new EAP8_0AddMetricsSubsystem<>())
+                                .subtask(new MigratePicketLinkSubsystem<>())
                                 .subtask(new MigrateDeployments<>())
                 )
                 .domain(serverUpdateBuilders.domainBuilder()
@@ -77,6 +79,7 @@ public class EAP7_2ToEAP8_0ServerMigrationProvider implements EAPServerMigration
                                 .subtask(legacySecurityConfigurationMigration.getEnsureBasicElytronSubsystem())
                                 .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityRealmsToElytron())
                                 .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityDomainsToElytron())
+                                .subtask(new MigratePicketLinkSubsystem<>())
                                 .subtask(new MigrateDeployments<>())
                         )
                         .hostConfigurations(serverUpdateBuilders.hostConfigurationBuilder()

--- a/migrations/eap8.0/eap7.3/src/main/java/org/jboss/migration/eap7/to/eap7/EAP7_3ToEAP8_0ServerMigrationProvider.java
+++ b/migrations/eap8.0/eap7.3/src/main/java/org/jboss/migration/eap7/to/eap7/EAP7_3ToEAP8_0ServerMigrationProvider.java
@@ -23,6 +23,7 @@ import org.jboss.migration.eap.task.subsystem.metrics.EAP8_0AddMetricsSubsystem;
 import org.jboss.migration.wfly.task.paths.WildFly26_0MigrateReferencedPaths;
 import org.jboss.migration.wfly.task.security.LegacySecurityConfigurationMigration;
 import org.jboss.migration.wfly.task.subsystem.health.WildFly26_0AddHealthSubsystem;
+import org.jboss.migration.wfly.task.subsystem.picketlink.MigratePicketLinkSubsystem;
 import org.jboss.migration.wfly.task.update.WildFly22_0UpdateInfinispanSubsystem;
 import org.jboss.migration.wfly.task.xml.WildFly26_0MigrateVault;
 import org.jboss.migration.wfly.task.xml.WildFly27_0MigrateJBossDomainProperties;
@@ -60,6 +61,7 @@ public class EAP7_3ToEAP8_0ServerMigrationProvider implements EAPServerMigration
                         .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityDomainsToElytron())
                         .subtask(new WildFly26_0AddHealthSubsystem<>())
                         .subtask(new EAP8_0AddMetricsSubsystem<>())
+                        .subtask(new MigratePicketLinkSubsystem<>())
                         .subtask(new MigrateDeployments<>())
                 )
                 .domain(serverUpdateBuilders.domainBuilder()
@@ -76,6 +78,7 @@ public class EAP7_3ToEAP8_0ServerMigrationProvider implements EAPServerMigration
                                 .subtask(legacySecurityConfigurationMigration.getEnsureBasicElytronSubsystem())
                                 .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityRealmsToElytron())
                                 .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityDomainsToElytron())
+                                .subtask(new MigratePicketLinkSubsystem<>())
                                 .subtask(new MigrateDeployments<>())
                         )
                         .hostConfigurations(serverUpdateBuilders.hostConfigurationBuilder()

--- a/migrations/eap8.0/eap7.3/src/main/java/org/jboss/migration/eap7/to/eap7/EAPXP7_3ToEAPXP8_0ServerMigrationProvider.java
+++ b/migrations/eap8.0/eap7.3/src/main/java/org/jboss/migration/eap7/to/eap7/EAPXP7_3ToEAPXP8_0ServerMigrationProvider.java
@@ -24,6 +24,7 @@ import org.jboss.migration.wfly.task.paths.WildFly26_0MigrateReferencedPaths;
 import org.jboss.migration.wfly.task.security.LegacySecurityConfigurationMigration;
 import org.jboss.migration.wfly.task.subsystem.health.WildFly26_0AddHealthSubsystem;
 import org.jboss.migration.wfly.task.subsystem.microprofile.WildFly26_0AddMicroprofileJwtSmallryeSubsystem;
+import org.jboss.migration.wfly.task.subsystem.picketlink.MigratePicketLinkSubsystem;
 import org.jboss.migration.wfly.task.xml.WildFly26_0MigrateVault;
 import org.jboss.migration.wfly.task.xml.WildFly27_0MigrateJBossDomainProperties;
 import org.jboss.migration.wfly10.WildFlyServer10;
@@ -59,6 +60,7 @@ public class EAPXP7_3ToEAPXP8_0ServerMigrationProvider implements EAPXPServerMig
                         .subtask(new WildFly26_0AddHealthSubsystem<>())
                         .subtask(new EAP8_0AddMetricsSubsystem<>())
                         .subtask(new WildFly26_0AddMicroprofileJwtSmallryeSubsystem<>())
+                        .subtask(new MigratePicketLinkSubsystem<>())
                 )
                 .domain(serverUpdateBuilders.domainBuilder()
                         .domainConfigurations(serverUpdateBuilders.domainConfigurationBuilder()
@@ -73,6 +75,7 @@ public class EAPXP7_3ToEAPXP8_0ServerMigrationProvider implements EAPXPServerMig
                                 .subtask(legacySecurityConfigurationMigration.getEnsureBasicElytronSubsystem())
                                 .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityRealmsToElytron())
                                 .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityDomainsToElytron())
+                                .subtask(new MigratePicketLinkSubsystem<>())
                         )
                         .hostConfigurations(serverUpdateBuilders.hostConfigurationBuilder()
                                 .subtask(new WildFly27_0MigrateJBossDomainProperties<>())

--- a/migrations/eap8.0/eap7.4/src/main/java/org/jboss/migration/eap7/to/eap7/EAP7_4ToEAP8_0ServerMigrationProvider.java
+++ b/migrations/eap8.0/eap7.4/src/main/java/org/jboss/migration/eap7/to/eap7/EAP7_4ToEAP8_0ServerMigrationProvider.java
@@ -21,6 +21,7 @@ import org.jboss.migration.eap.EAPServerMigrationProvider8_0;
 import org.jboss.migration.eap.task.hostexclude.EAP8_0AddHostExcludes;
 import org.jboss.migration.wfly.task.paths.WildFly26_0MigrateReferencedPaths;
 import org.jboss.migration.wfly.task.security.LegacySecurityConfigurationMigration;
+import org.jboss.migration.wfly.task.subsystem.picketlink.MigratePicketLinkSubsystem;
 import org.jboss.migration.wfly.task.xml.WildFly26_0MigrateVault;
 import org.jboss.migration.wfly.task.xml.WildFly27_0MigrateJBossDomainProperties;
 import org.jboss.migration.wfly10.WildFlyServer10;
@@ -53,6 +54,7 @@ public class EAP7_4ToEAP8_0ServerMigrationProvider implements EAPServerMigration
                         .subtask(legacySecurityConfigurationMigration.getEnsureBasicElytronSubsystem())
                         .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityRealmsToElytron())
                         .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityDomainsToElytron())
+                        .subtask(new MigratePicketLinkSubsystem<>())
                         .subtask(new MigrateDeployments<>())
                 )
                 .domain(serverUpdateBuilders.domainBuilder()
@@ -68,6 +70,7 @@ public class EAP7_4ToEAP8_0ServerMigrationProvider implements EAPServerMigration
                                 .subtask(legacySecurityConfigurationMigration.getEnsureBasicElytronSubsystem())
                                 .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityRealmsToElytron())
                                 .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityDomainsToElytron())
+                                .subtask(new MigratePicketLinkSubsystem<>())
                                 .subtask(new MigrateDeployments<>())
                         )
                         .hostConfigurations(serverUpdateBuilders.hostConfigurationBuilder()

--- a/migrations/eap8.0/eap7.4/src/main/java/org/jboss/migration/eap7/to/eap7/EAPXP7_4ToEAPXP8_0ServerMigrationProvider.java
+++ b/migrations/eap8.0/eap7.4/src/main/java/org/jboss/migration/eap7/to/eap7/EAPXP7_4ToEAPXP8_0ServerMigrationProvider.java
@@ -21,6 +21,7 @@ import org.jboss.migration.eap.EAPXPServerMigrationProvider8_0;
 import org.jboss.migration.eap.task.hostexclude.EAP8_0AddHostExcludes;
 import org.jboss.migration.wfly.task.paths.WildFly26_0MigrateReferencedPaths;
 import org.jboss.migration.wfly.task.security.LegacySecurityConfigurationMigration;
+import org.jboss.migration.wfly.task.subsystem.picketlink.MigratePicketLinkSubsystem;
 import org.jboss.migration.wfly.task.xml.WildFly26_0MigrateVault;
 import org.jboss.migration.wfly.task.xml.WildFly27_0MigrateJBossDomainProperties;
 import org.jboss.migration.wfly10.WildFlyServer10;
@@ -53,6 +54,7 @@ public class EAPXP7_4ToEAPXP8_0ServerMigrationProvider implements EAPXPServerMig
                         .subtask(legacySecurityConfigurationMigration.getEnsureBasicElytronSubsystem())
                         .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityRealmsToElytron())
                         .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityDomainsToElytron())
+                        .subtask(new MigratePicketLinkSubsystem<>())
                 )
                 .domain(serverUpdateBuilders.domainBuilder()
                         .domainConfigurations(serverUpdateBuilders.domainConfigurationBuilder()
@@ -66,6 +68,7 @@ public class EAPXP7_4ToEAPXP8_0ServerMigrationProvider implements EAPXPServerMig
                                 .subtask(legacySecurityConfigurationMigration.getEnsureBasicElytronSubsystem())
                                 .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityRealmsToElytron())
                                 .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityDomainsToElytron())
+                                .subtask(new MigratePicketLinkSubsystem<>())
                         )
                         .hostConfigurations(serverUpdateBuilders.hostConfigurationBuilder()
                                 .subtask(new WildFly27_0MigrateJBossDomainProperties<>())

--- a/migrations/wildfly27.0/wildfly18.0/src/main/java/org/jboss/migration/wfly/WildFly18_0ToWildFly27_0ServerMigrationProvider.java
+++ b/migrations/wildfly27.0/wildfly18.0/src/main/java/org/jboss/migration/wfly/WildFly18_0ToWildFly27_0ServerMigrationProvider.java
@@ -21,6 +21,7 @@ import org.jboss.migration.wfly.task.security.LegacySecurityConfigurationMigrati
 import org.jboss.migration.wfly.task.subsystem.health.WildFly26_0AddHealthSubsystem;
 import org.jboss.migration.wfly.task.subsystem.metrics.WildFly26_0AddMetricsSubsystem;
 import org.jboss.migration.wfly.task.subsystem.microprofile.WildFly26_0AddMicroprofileJwtSmallryeSubsystem;
+import org.jboss.migration.wfly.task.subsystem.picketlink.MigratePicketLinkSubsystem;
 import org.jboss.migration.wfly.task.update.WildFly22_0UpdateInfinispanSubsystem;
 import org.jboss.migration.wfly.task.xml.WildFly27_0MigrateJBossDomainProperties;
 import org.jboss.migration.wfly.task.xml.WildFly26_0MigrateVault;
@@ -58,6 +59,7 @@ public class WildFly18_0ToWildFly27_0ServerMigrationProvider implements WildFly2
                         .subtask(new WildFly26_0AddHealthSubsystem<>())
                         .subtask(new WildFly26_0AddMetricsSubsystem<>())
                         .subtask(new WildFly26_0AddMicroprofileJwtSmallryeSubsystem<>())
+                        .subtask(new MigratePicketLinkSubsystem<>())
                 )
                 .domain(serverUpdateBuilders.domainBuilder()
                         .domainConfigurations(serverUpdateBuilders.domainConfigurationBuilder()
@@ -73,6 +75,7 @@ public class WildFly18_0ToWildFly27_0ServerMigrationProvider implements WildFly2
                                 .subtask(legacySecurityConfigurationMigration.getEnsureBasicElytronSubsystem())
                                 .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityRealmsToElytron())
                                 .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityDomainsToElytron())
+                                .subtask(new MigratePicketLinkSubsystem<>())
                         )
                         .hostConfigurations(serverUpdateBuilders.hostConfigurationBuilder()
                                 .subtask(new WildFly27_0MigrateJBossDomainProperties<>())

--- a/migrations/wildfly27.0/wildfly19.0/src/main/java/org/jboss/migration/wfly/WildFly19_0ToWildFly27_0ServerMigrationProvider.java
+++ b/migrations/wildfly27.0/wildfly19.0/src/main/java/org/jboss/migration/wfly/WildFly19_0ToWildFly27_0ServerMigrationProvider.java
@@ -20,6 +20,7 @@ import org.jboss.migration.wfly.task.paths.WildFly26_0MigrateReferencedPaths;
 import org.jboss.migration.wfly.task.security.LegacySecurityConfigurationMigration;
 import org.jboss.migration.wfly.task.subsystem.health.WildFly26_0AddHealthSubsystem;
 import org.jboss.migration.wfly.task.subsystem.metrics.WildFly26_0AddMetricsSubsystem;
+import org.jboss.migration.wfly.task.subsystem.picketlink.MigratePicketLinkSubsystem;
 import org.jboss.migration.wfly.task.update.WildFly22_0UpdateInfinispanSubsystem;
 import org.jboss.migration.wfly.task.xml.WildFly27_0MigrateJBossDomainProperties;
 import org.jboss.migration.wfly.task.xml.WildFly26_0MigrateVault;
@@ -56,6 +57,7 @@ public class WildFly19_0ToWildFly27_0ServerMigrationProvider implements WildFly2
                         .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityDomainsToElytron())
                         .subtask(new WildFly26_0AddHealthSubsystem<>())
                         .subtask(new WildFly26_0AddMetricsSubsystem<>())
+                        .subtask(new MigratePicketLinkSubsystem<>())
                 )
                 .domain(serverUpdateBuilders.domainBuilder()
                         .domainConfigurations(serverUpdateBuilders.domainConfigurationBuilder()
@@ -70,6 +72,7 @@ public class WildFly19_0ToWildFly27_0ServerMigrationProvider implements WildFly2
                                 .subtask(legacySecurityConfigurationMigration.getEnsureBasicElytronSubsystem())
                                 .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityRealmsToElytron())
                                 .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityDomainsToElytron())
+                                .subtask(new MigratePicketLinkSubsystem<>())
                         )
                         .hostConfigurations(serverUpdateBuilders.hostConfigurationBuilder()
                                 .subtask(new WildFly27_0MigrateJBossDomainProperties<>())

--- a/migrations/wildfly27.0/wildfly20.0/src/main/java/org/jboss/migration/wfly/WildFly20_0ToWildFly27_0ServerMigrationProvider.java
+++ b/migrations/wildfly27.0/wildfly20.0/src/main/java/org/jboss/migration/wfly/WildFly20_0ToWildFly27_0ServerMigrationProvider.java
@@ -20,6 +20,7 @@ import org.jboss.migration.wfly.task.paths.WildFly26_0MigrateReferencedPaths;
 import org.jboss.migration.wfly.task.security.LegacySecurityConfigurationMigration;
 import org.jboss.migration.wfly.task.subsystem.health.WildFly26_0AddHealthSubsystem;
 import org.jboss.migration.wfly.task.subsystem.metrics.WildFly26_0AddMetricsSubsystem;
+import org.jboss.migration.wfly.task.subsystem.picketlink.MigratePicketLinkSubsystem;
 import org.jboss.migration.wfly.task.update.WildFly22_0UpdateInfinispanSubsystem;
 import org.jboss.migration.wfly.task.xml.WildFly26_0MigrateVault;
 import org.jboss.migration.wfly.task.xml.WildFly27_0MigrateJBossDomainProperties;
@@ -56,6 +57,7 @@ public class WildFly20_0ToWildFly27_0ServerMigrationProvider implements WildFly2
                         .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityDomainsToElytron())
                         .subtask(new WildFly26_0AddHealthSubsystem<>())
                         .subtask(new WildFly26_0AddMetricsSubsystem<>())
+                        .subtask(new MigratePicketLinkSubsystem<>())
                 )
                 .domain(serverUpdateBuilders.domainBuilder()
                         .domainConfigurations(serverUpdateBuilders.domainConfigurationBuilder()
@@ -70,6 +72,7 @@ public class WildFly20_0ToWildFly27_0ServerMigrationProvider implements WildFly2
                                 .subtask(legacySecurityConfigurationMigration.getEnsureBasicElytronSubsystem())
                                 .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityRealmsToElytron())
                                 .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityDomainsToElytron())
+                                .subtask(new MigratePicketLinkSubsystem<>())
                         )
                         .hostConfigurations(serverUpdateBuilders.hostConfigurationBuilder()
                                 .subtask(new WildFly27_0MigrateJBossDomainProperties<>())

--- a/migrations/wildfly27.0/wildfly21.0/src/main/java/org/jboss/migration/wfly/WildFly21_0ToWildFly27_0ServerMigrationProvider.java
+++ b/migrations/wildfly27.0/wildfly21.0/src/main/java/org/jboss/migration/wfly/WildFly21_0ToWildFly27_0ServerMigrationProvider.java
@@ -20,6 +20,7 @@ import org.jboss.migration.wfly.task.paths.WildFly26_0MigrateReferencedPaths;
 import org.jboss.migration.wfly.task.security.LegacySecurityConfigurationMigration;
 import org.jboss.migration.wfly.task.subsystem.health.WildFly26_0AddHealthSubsystem;
 import org.jboss.migration.wfly.task.subsystem.metrics.WildFly26_0AddMetricsSubsystem;
+import org.jboss.migration.wfly.task.subsystem.picketlink.MigratePicketLinkSubsystem;
 import org.jboss.migration.wfly.task.update.WildFly22_0UpdateInfinispanSubsystem;
 import org.jboss.migration.wfly.task.xml.WildFly26_0MigrateVault;
 import org.jboss.migration.wfly.task.xml.WildFly27_0MigrateJBossDomainProperties;
@@ -56,6 +57,7 @@ public class WildFly21_0ToWildFly27_0ServerMigrationProvider implements WildFly2
                         .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityDomainsToElytron())
                         .subtask(new WildFly26_0AddHealthSubsystem<>())
                         .subtask(new WildFly26_0AddMetricsSubsystem<>())
+                        .subtask(new MigratePicketLinkSubsystem<>())
                 )
                 .domain(serverUpdateBuilders.domainBuilder()
                         .domainConfigurations(serverUpdateBuilders.domainConfigurationBuilder()
@@ -70,6 +72,7 @@ public class WildFly21_0ToWildFly27_0ServerMigrationProvider implements WildFly2
                                 .subtask(legacySecurityConfigurationMigration.getEnsureBasicElytronSubsystem())
                                 .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityRealmsToElytron())
                                 .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityDomainsToElytron())
+                                .subtask(new MigratePicketLinkSubsystem<>())
                         )
                         .hostConfigurations(serverUpdateBuilders.hostConfigurationBuilder()
                                 .subtask(new WildFly27_0MigrateJBossDomainProperties<>())

--- a/migrations/wildfly27.0/wildfly22.0/src/main/java/org/jboss/migration/wfly/WildFly22_0ToWildFly27_0ServerMigrationProvider.java
+++ b/migrations/wildfly27.0/wildfly22.0/src/main/java/org/jboss/migration/wfly/WildFly22_0ToWildFly27_0ServerMigrationProvider.java
@@ -18,6 +18,7 @@ package org.jboss.migration.wfly;
 import org.jboss.migration.wfly.task.hostexclude.WildFly27_0AddHostExcludes;
 import org.jboss.migration.wfly.task.paths.WildFly26_0MigrateReferencedPaths;
 import org.jboss.migration.wfly.task.security.LegacySecurityConfigurationMigration;
+import org.jboss.migration.wfly.task.subsystem.picketlink.MigratePicketLinkSubsystem;
 import org.jboss.migration.wfly.task.update.WildFly22_0UpdateInfinispanSubsystem;
 import org.jboss.migration.wfly.task.xml.WildFly26_0MigrateVault;
 import org.jboss.migration.wfly.task.xml.WildFly27_0MigrateJBossDomainProperties;
@@ -52,6 +53,7 @@ public class WildFly22_0ToWildFly27_0ServerMigrationProvider implements WildFly2
                         .subtask(legacySecurityConfigurationMigration.getEnsureBasicElytronSubsystem())
                         .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityRealmsToElytron())
                         .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityDomainsToElytron())
+                        .subtask(new MigratePicketLinkSubsystem<>())
                 )
                 .domain(serverUpdateBuilders.domainBuilder()
                         .domainConfigurations(serverUpdateBuilders.domainConfigurationBuilder()
@@ -66,6 +68,7 @@ public class WildFly22_0ToWildFly27_0ServerMigrationProvider implements WildFly2
                                 .subtask(legacySecurityConfigurationMigration.getEnsureBasicElytronSubsystem())
                                 .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityRealmsToElytron())
                                 .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityDomainsToElytron())
+                                .subtask(new MigratePicketLinkSubsystem<>())
                         )
                         .hostConfigurations(serverUpdateBuilders.hostConfigurationBuilder()
                                 .subtask(new WildFly27_0MigrateJBossDomainProperties<>())

--- a/migrations/wildfly27.0/wildfly23.0/src/main/java/org/jboss/migration/wfly/WildFly23_0ToWildFly27_0ServerMigrationProvider.java
+++ b/migrations/wildfly27.0/wildfly23.0/src/main/java/org/jboss/migration/wfly/WildFly23_0ToWildFly27_0ServerMigrationProvider.java
@@ -18,6 +18,7 @@ package org.jboss.migration.wfly;
 import org.jboss.migration.wfly.task.hostexclude.WildFly27_0AddHostExcludes;
 import org.jboss.migration.wfly.task.paths.WildFly26_0MigrateReferencedPaths;
 import org.jboss.migration.wfly.task.security.LegacySecurityConfigurationMigration;
+import org.jboss.migration.wfly.task.subsystem.picketlink.MigratePicketLinkSubsystem;
 import org.jboss.migration.wfly.task.xml.WildFly26_0MigrateVault;
 import org.jboss.migration.wfly.task.xml.WildFly27_0MigrateJBossDomainProperties;
 import org.jboss.migration.wfly10.WildFlyServer10;
@@ -50,6 +51,7 @@ public class WildFly23_0ToWildFly27_0ServerMigrationProvider implements WildFly2
                         .subtask(legacySecurityConfigurationMigration.getEnsureBasicElytronSubsystem())
                         .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityRealmsToElytron())
                         .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityDomainsToElytron())
+                        .subtask(new MigratePicketLinkSubsystem<>())
                 )
                 .domain(serverUpdateBuilders.domainBuilder()
                         .domainConfigurations(serverUpdateBuilders.domainConfigurationBuilder()
@@ -63,6 +65,7 @@ public class WildFly23_0ToWildFly27_0ServerMigrationProvider implements WildFly2
                                 .subtask(legacySecurityConfigurationMigration.getEnsureBasicElytronSubsystem())
                                 .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityRealmsToElytron())
                                 .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityDomainsToElytron())
+                                .subtask(new MigratePicketLinkSubsystem<>())
                         )
                         .hostConfigurations(serverUpdateBuilders.hostConfigurationBuilder()
                                 .subtask(new WildFly27_0MigrateJBossDomainProperties<>())

--- a/migrations/wildfly27.0/wildfly24.0/src/main/java/org/jboss/migration/wfly/WildFly24_0ToWildFly27_0ServerMigrationProvider.java
+++ b/migrations/wildfly27.0/wildfly24.0/src/main/java/org/jboss/migration/wfly/WildFly24_0ToWildFly27_0ServerMigrationProvider.java
@@ -18,6 +18,7 @@ package org.jboss.migration.wfly;
 import org.jboss.migration.wfly.task.hostexclude.WildFly27_0AddHostExcludes;
 import org.jboss.migration.wfly.task.paths.WildFly26_0MigrateReferencedPaths;
 import org.jboss.migration.wfly.task.security.LegacySecurityConfigurationMigration;
+import org.jboss.migration.wfly.task.subsystem.picketlink.MigratePicketLinkSubsystem;
 import org.jboss.migration.wfly.task.xml.WildFly26_0MigrateVault;
 import org.jboss.migration.wfly.task.xml.WildFly27_0MigrateJBossDomainProperties;
 import org.jboss.migration.wfly10.WildFlyServer10;
@@ -50,6 +51,7 @@ public class WildFly24_0ToWildFly27_0ServerMigrationProvider implements WildFly2
                         .subtask(legacySecurityConfigurationMigration.getEnsureBasicElytronSubsystem())
                         .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityRealmsToElytron())
                         .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityDomainsToElytron())
+                        .subtask(new MigratePicketLinkSubsystem<>())
                 )
                 .domain(serverUpdateBuilders.domainBuilder()
                         .domainConfigurations(serverUpdateBuilders.domainConfigurationBuilder()
@@ -63,6 +65,7 @@ public class WildFly24_0ToWildFly27_0ServerMigrationProvider implements WildFly2
                                 .subtask(legacySecurityConfigurationMigration.getEnsureBasicElytronSubsystem())
                                 .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityRealmsToElytron())
                                 .subtask(legacySecurityConfigurationMigration.getMigrateLegacySecurityDomainsToElytron())
+                                .subtask(new MigratePicketLinkSubsystem<>())
                         )
                         .hostConfigurations(serverUpdateBuilders.hostConfigurationBuilder()
                                 .subtask(new WildFly27_0MigrateJBossDomainProperties<>())

--- a/migrations/wildfly27.0/wildfly25.0/src/main/java/org/jboss/migration/wfly/WildFly25_0ToWildFly27_0ServerMigrationProvider.java
+++ b/migrations/wildfly27.0/wildfly25.0/src/main/java/org/jboss/migration/wfly/WildFly25_0ToWildFly27_0ServerMigrationProvider.java
@@ -17,6 +17,7 @@ package org.jboss.migration.wfly;
 
 import org.jboss.migration.wfly.task.hostexclude.WildFly27_0AddHostExcludes;
 import org.jboss.migration.wfly.task.paths.WildFly26_0MigrateReferencedPaths;
+import org.jboss.migration.wfly.task.subsystem.picketlink.MigratePicketLinkSubsystem;
 import org.jboss.migration.wfly.task.xml.WildFly27_0MigrateJBossDomainProperties;
 import org.jboss.migration.wfly10.WildFlyServer10;
 import org.jboss.migration.wfly10.WildFlyServerMigration10;
@@ -41,6 +42,7 @@ public class WildFly25_0ToWildFly27_0ServerMigrationProvider implements WildFly2
                         .subtask(new RemoveUnsupportedSubsystems<>())
                         .subtask(new MigrateReferencedModules<>())
                         .subtask(new WildFly26_0MigrateReferencedPaths<>())
+                        .subtask(new MigratePicketLinkSubsystem<>())
                 )
                 .domain(serverUpdateBuilders.domainBuilder()
                         .domainConfigurations(serverUpdateBuilders.domainConfigurationBuilder()
@@ -50,6 +52,7 @@ public class WildFly25_0ToWildFly27_0ServerMigrationProvider implements WildFly2
                                 .subtask(new MigrateReferencedModules<>())
                                 .subtask(new WildFly26_0MigrateReferencedPaths<>())
                                 .subtask(new WildFly27_0AddHostExcludes<>())
+                                .subtask(new MigratePicketLinkSubsystem<>())
                         )
                         .hostConfigurations(serverUpdateBuilders.hostConfigurationBuilder()
                                 .subtask(new WildFly27_0MigrateJBossDomainProperties<>())

--- a/servers/wildfly10.0/src/main/java/org/jboss/migration/wfly10/dist/full/WildFlyFullServer10_0.java
+++ b/servers/wildfly10.0/src/main/java/org/jboss/migration/wfly10/dist/full/WildFlyFullServer10_0.java
@@ -53,6 +53,7 @@ public class WildFlyFullServer10_0 extends WildFlyServer10 {
             .extension(JBossExtensions.MODCLUSTER)
             .extension(JBossExtensions.NAMING)
             .extension(JBossExtensions.POJO)
+            .extension(JBossExtensions.PICKETLINK)
             .extension(JBossExtensions.REMOTING)
             .extension(JBossExtensions.REQUEST_CONTROLLER)
             .extension(JBossExtensions.SAR)

--- a/servers/wildfly27.0/src/main/java/org/jboss/migration/wfly/task/subsystem/picketlink/MigratePicketLinkSubsystem.java
+++ b/servers/wildfly27.0/src/main/java/org/jboss/migration/wfly/task/subsystem/picketlink/MigratePicketLinkSubsystem.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.migration.wfly.task.subsystem.picketlink;
+
+import org.jboss.migration.core.jboss.JBossExtensionNames;
+import org.jboss.migration.core.jboss.JBossSubsystemNames;
+import org.jboss.migration.wfly10.config.task.management.subsystem.MigrateSubsystemResources;
+
+/**
+ * @author istudens
+ */
+public class MigratePicketLinkSubsystem<S> extends MigrateSubsystemResources<S> {
+    public MigratePicketLinkSubsystem() {
+        super(JBossExtensionNames.PICKETLINK, JBossSubsystemNames.PICKETLINK_FEDERATION);
+    }
+}


### PR DESCRIPTION
…eycloak-saml

Issue: https://issues.redhat.com/browse/CMTOOL-320

At the moment the migration only supports an empty configuration of the picketlink-federation subsystem and requires the Keycloak client SAML adapter installed in the target server.