### PR TITLE
Update Wildfly3[5-8]_0ServerProvider::getProductNameRegex()

### DIFF
--- a/servers/wildfly35.0/src/main/java/org/jboss/migration/wfly/WildFly35_0ServerProvider.java
+++ b/servers/wildfly35.0/src/main/java/org/jboss/migration/wfly/WildFly35_0ServerProvider.java
@@ -29,7 +29,7 @@ public class WildFly35_0ServerProvider extends WildFly34_0ServerProvider {
 
     @Override
     protected String getProductNameRegex() {
-        return "WildFly";
+        return "WildFly( EE)?";
     }
 
     @Override

--- a/servers/wildfly36.0/src/main/java/org/jboss/migration/wfly/WildFly36_0ServerProvider.java
+++ b/servers/wildfly36.0/src/main/java/org/jboss/migration/wfly/WildFly36_0ServerProvider.java
@@ -18,7 +18,7 @@ public class WildFly36_0ServerProvider extends WildFly35_0ServerProvider {
 
     @Override
     protected String getProductNameRegex() {
-        return "WildFly";
+        return "WildFly( EE)?";
     }
 
     @Override

--- a/servers/wildfly37.0/src/main/java/org/jboss/migration/wfly/WildFly37_0ServerProvider.java
+++ b/servers/wildfly37.0/src/main/java/org/jboss/migration/wfly/WildFly37_0ServerProvider.java
@@ -18,7 +18,7 @@ public class WildFly37_0ServerProvider extends WildFly36_0ServerProvider {
 
     @Override
     protected String getProductNameRegex() {
-        return "WildFly";
+        return "WildFly( EE)?";
     }
 
     @Override

--- a/servers/wildfly38.0/src/main/java/org/jboss/migration/wfly/WildFly38_0ServerProvider.java
+++ b/servers/wildfly38.0/src/main/java/org/jboss/migration/wfly/WildFly38_0ServerProvider.java
@@ -18,7 +18,7 @@ public class WildFly38_0ServerProvider extends WildFly37_0ServerProvider {
 
     @Override
     protected String getProductNameRegex() {
-        return "WildFly";
+        return "WildFly( EE)?";
     }
 
     @Override


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/CMTOOL-394

- extend the regex to cover the product name string returned by wildfly "images" produced by galleon

From Wildfly 35 onward it because necessary to use Galleon to provision with the Keycloak SAML adapter, with a `provisioning.xml` like the following:
```
<?xml version="1.0" ?>

<installation xmlns="urn:jboss:galleon:provisioning:3.0">
    <feature-pack location="wildfly-ee@maven(org.jboss.universe:community-universe):current#37.0.1.Final"/>
    <feature-pack location="org.keycloak:keycloak-saml-adapter-galleon-pack:26.3.3">
        <default-configs inherit="false"/>
        <packages inherit="false"/>
    </feature-pack>
    <config model="standalone" name="standalone.xml">
        <layers>
            <include name="keycloak-client-saml"/>
        </layers>
    </config>
    <options>
        <option name="optional-packages" value="passive+"/>
    </options>
</installation>
```
When attempting the migrate to a new version the product regex would fail to recognize the source and target product names and fail. This PR updates the regex, adding an optional ` EE` to the product name.