### PR TITLE
[CMTOOL-418] adds AI agent wiki (_context/wiki/) and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Agent Rules
+
+## Start with the wiki
+
+At the start of each task, check `_context/wiki/index.md` to decide
+whether wiki context is needed before acting. Don't read the wiki in
+full. Use the index and follow links only when they are relevant to
+the task.
+
+## Update the wiki
+
+After completing a task, offer to update the wiki if the task yielded durable knowledge that could benefit future work, then wait for user approval. This includes new processes, architecture decisions, or insights that go beyond the immediate task.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ It is recommended that you use a separate branch for every issue you work on. To
 ## Setting up your Developer Environment
 You will need:
 
-* JDK 8
+* JDK 17+
 * Git
 * Maven
 * An [IDE](https://en.wikipedia.org/wiki/Comparison_of_integrated_development_environments#Java)

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Run the Server Migration Tool (Standalone Build)
         For Linux|Mac:   ./jboss-server-migration.sh -s SOURCE_SERVER_PATH -t TARGET_SERVER_PATH
         For Windows: jboss-server-migration.bat -s SOURCE_SERVER_PATH -t TARGET_SERVER_PATH
 
-    Replace `SOURCE_SERVER_PATH` with the path to previous version of the server installation that you want to migrate from, for example:  `${user.home}/wildfly-29.0.0.Final/`
+    Replace `SOURCE_SERVER_PATH` with the path to previous version of the server installation that you want to migrate from, for example:  `${user.home}/wildfly-41.0.0.Final/`
 
-    Replace `TARGET_SERVER_PATH` with the path to current version of the server installation that you want the old configuration migrated to, for example:  `${user.home}/wildfly-39.0.0.Final/`
+    Replace `TARGET_SERVER_PATH` with the path to current version of the server installation that you want the old configuration migrated to, for example:  `${user.home}/wildfly-42.0.0.Final-SNAPSHOT/`
 4. When you execute the command, the tool identifies the source and target servers from provided paths, and starts the server migration.
 
         ----------------------------------------------------------

--- a/_context/wiki/index.md
+++ b/_context/wiki/index.md
@@ -1,0 +1,23 @@
+# JBoss Server Migration Tool — Wiki
+
+Concise orientation for AI agents and contributors. Follow links only when they are relevant to the task at hand.
+
+## Pages
+
+| File | Contents |
+|---|---|
+| [project.md](project.md) | Goals, key modules, architecture notes, and workflow pointers — developer context not covered by the READMEs |
+| [preferences.md](preferences.md) | Code style, AI collaboration rules, commit conventions (with links to canonical sources) |
+| [../README.md](../README.md) | End-user guide: what the tool does, build instructions, sample migration run |
+| [../CONTRIBUTING.md](../CONTRIBUTING.md) | Contribution guide: fork/clone setup, JIRA workflow, PR and commit message format |
+| [../maintenance/README.md](../maintenance/README.md) | Maintenance scripts: add/remove WildFly and EAP server versions, set project version |
+| [../testsuite/README.md](../testsuite/README.md) | Integration testsuite: architecture, server cache, running tests, CI |
+
+
+## Quick facts
+
+- **Repo:** `wildfly/wildfly-server-migration` (GitHub)
+- **Language:** Java 17+, Maven multi-module
+- **Issue tracker:** [JIRA CMTOOL](https://issues.redhat.com/projects/CMTOOL/issues)
+- **Default branch:** `main`
+- **Build:** `mvn clean install` (unit tests) · `mvn install -DrunITs` (+ integration tests)

--- a/_context/wiki/preferences.md
+++ b/_context/wiki/preferences.md
@@ -1,0 +1,57 @@
+# Working Preferences
+
+## Code style
+
+- **Consistency first** — match the existing style, naming conventions, and patterns in the file or module being edited. Do not introduce a new style unless the entire module is being updated.
+- **Java** — follow the conventions already present (JBoss project style): no trailing whitespace, 4-space indentation, Javadoc on public API.
+- **Maven** — keep `pom.xml` files consistent with sibling modules (same plugin versions, dependency scopes, etc.).
+- **Documentation** — keep `README.md` files consistent with existing docs in structure and voice.
+- **Minimal diffs** — produce the smallest change that solves the problem. Do not refactor, clean up, or reformat code that is unrelated to the task.
+
+---
+
+## Refactoring approach
+
+- **Proactive** — if the AI spots a clear improvement opportunity directly related to the task (e.g., a repeated pattern that the new code should also follow), it should raise it and apply it unless told otherwise.
+- **Unrelated code** — do not touch code that is not directly related to the task even if it looks improvable.
+
+---
+
+## Commit messages and pull requests
+
+See [`CONTRIBUTING.md`](../CONTRIBUTING.md) for the canonical rules. Key points for AI context:
+
+- Commit message format: `[CMTOOL-XXX] short imperative description` (multiple issues: `[CMTOOL-XXX][CMTOOL-YYY] …`).
+- PR title must match the commit message format.
+- PR description must include a link to the JIRA issue.
+- Branch naming: use the JIRA issue number, e.g., `CMTOOL-338`.
+
+---
+
+## AI collaboration preferences
+
+- **Proactive** — suggest improvements when they are directly related to the task; don't ask for permission first.
+- **No explanations unless asked** — skip preamble and narration; just show the diff or the result.
+- **Grounded answers only** — read the relevant file before answering questions about code; never speculate.
+- **Investigate before acting** — for non-trivial changes, check the reference modules (`servers/wildfly41.0`, `core`) before writing new code, to ensure the implementation matches existing patterns.
+- **Consistent with existing reference modules** — when adding a new server or migration module, use `servers/wildfly41.0` as the primary template.
+
+---
+
+## Testing
+
+- Unit tests live in `core/src/test/` and companion `src/test/` directories within each module.
+- Integration tests live under `testsuite/integration-tests/` and require `-DrunITs`. See [`testsuite/README.md`](../testsuite/README.md) for the full command reference.
+- EAP integration tests require `testsuite.eapServersDir` to be set; they silently skip when it is not.
+- After any change to server or migration modules, run the relevant IT module to verify:
+  ```bash
+  mvn -f testsuite/integration-tests/wildfly42.0/pom.xml verify
+  ```
+
+---
+
+## Adding new server / migration support
+
+Always use the maintenance scripts as the starting point — see [`maintenance/README.md`](../maintenance/README.md) for usage and what each script does.
+
+Reference the most recent WildFly server module (`servers/wildfly41.0` or higher) for how tasks are structured.

--- a/_context/wiki/project.md
+++ b/_context/wiki/project.md
@@ -1,0 +1,107 @@
+# Project Overview
+
+## What is this project?
+
+See [`README.md`](../README.md) for the user-facing description, build instructions, and a sample migration run.
+
+**GitHub:** https://github.com/wildfly/wildfly-server-migration  
+**Issue tracker:** https://issues.redhat.com/projects/CMTOOL/issues
+
+---
+
+## Main goals and objectives
+
+1. **Correctness** — every migrated configuration must boot successfully in the target server (verified by the integration testsuite via embedded WildFly/EAP boot checks).
+2. **Extensibility** — adding support for a new WildFly or EAP target version should require minimal code and effort. The maintenance scripts (`maintenance/add-server-wfly.sh`, `maintenance/add-server-eap.sh`) scaffold new server, migrations, and integration-test modules automatically.
+3. **Low maintenance overhead** — the integration testsuite discovers source/target version pairs dynamically from the `migrations/` directory tree, so no hardcoded lists need updating when versions are added or removed.
+
+---
+
+## Key stakeholders / users
+
+- **External users** — WildFly and JBoss EAP operators who need to upgrade their server installations.
+- **Red Hat / WildFly contributors** — maintain the tool and add support for new server releases.
+- **CI** — GitHub Actions runs the full WildFly IT suite on every push (JDK 17 & 25 × Ubuntu & Windows).
+
+---
+
+## Repository layout
+
+```
+core/                    Core API/SPI (server, task, env, XML utilities)
+servers/                 Server modules
+  wildflyX.Y/            WildFly version X.Y server module
+  eapX.Y/                JBoss EAP version X.Y server module
+migrations/              Migration modules
+  wildflyX2.Y2/          Migrations to WildFly X2.Y2
+    wildflyX1.Y1/        Migration from WildFly X1.Y1 → WildFly X2.Y2
+  eapX2.Y2/              Migrations to EAP X2.Y2
+    eapX1.Y1/            Migration from EAP X1.Y1 → EAP X2.Y2
+testsuite/               Integration testsuite (see testsuite/README.md)
+cli/                     CLI entry point
+dist/                    Distribution packaging
+maintenance/             Shell scripts to add/remove server and migration modules
+docs/                    User-facing documentation
+```
+
+---
+
+## Important modules
+
+### `core`
+
+The foundation. Defines the main API/SPI interfaces every server module must implement:
+
+| Package / class | Role |
+|---|---|
+| `core.Server` / `AbstractServer` | Server identity and resource discovery |
+| `core.ServerProvider` / `AbstractServerProvider` | Detects a server from a filesystem path |
+| `core.ServerMigration` | Orchestrates source → target migration |
+| `core.task.*` | Task model: `ServerMigrationTask`, `TaskContext`, composite/leaf task builders |
+| `core.jboss.*` | JBoss-specific abstractions: `JBossServer`, `JBossServerConfiguration`, `ModulesMigrationTask`, `XmlConfigurationMigration`, `Subsystem`, `Extension` |
+| `core.env.*` | Environment / property system for task configuration and skipping |
+| `core.util.xml.*` | Low-level XML DOM utilities used by configuration migration tasks |
+| `core.report.*` | HTML, XML, and summary report writers |
+
+### `servers/wildfly10.0`
+
+The WildFly 10.0 server module introduced most of the SPI used by current migration and server modules.
+
+### `servers/wildfly41.0`
+
+The WildFly 41.0 server module introduced higher-level SPI elements that require less maintenance, such as auto-discovery of supported extensions/subsystems and domain host-excludes configuration. Use this as the **primary reference** when implementing a new server or migration module.
+
+| Class | Role |
+|---|---|
+| `WildFly41_0Server` | Server implementation |
+| `WildFly41_0ServerProvider` | Detects WildFly 41.0 from path |
+| `WildFly41_0ServerMigrationProvider` | Wires together all migration tasks |
+| `WildFly41_0AddHostExcludes` | Host-excludes migration task |
+| `WildFly41_0MigrateReferencedPaths` | Resolvable-paths migration task |
+| `WildFly41_0UpdateElytronSubsystem` | Elytron subsystem update task |
+| `SupportedExtensionsDiscovery` / `HostExcludesDiscovery` | Discovery helpers shared across recent WildFly versions |
+
+### `migrations/<target>/`
+
+Each subdirectory represents a supported source-version migration for that target. The directory names drive both the testsuite (source version discovery) and the server cache population.
+
+---
+
+## Key workflows
+
+### Adding or removing a WildFly or EAP server version
+
+See [`maintenance/README.md`](../maintenance/README.md) — the maintenance scripts handle add/remove for both WildFly and EAP, and scaffold server modules, migration modules, docs, integration-tests, and all POM updates automatically.
+
+### Running integration tests
+
+See the [testsuite README](../testsuite/README.md#running-the-tests) for the full command reference, JDK compatibility matrix, and CI setup.
+
+---
+
+## Architecture notes
+
+- Server identification uses the Java `ServiceLoader` mechanism: each server module registers its `ServerProvider` implementation via `META-INF/services/org.jboss.migration.core.ServerProvider`.
+- Migration tasks form a tree; `CompositeTask` / `LeafTask` builders in `core.task.component` are the primary composition primitives.
+- Environment properties (`core.env`) allow tasks to be skipped or configured without code changes — useful for non-interactive / automated migrations.
+- `XmlConfigurationMigration` in `core.jboss` is the base for all XML-level configuration migrations; per-subsystem tasks extend it.


### PR DESCRIPTION
https://redhat.atlassian.net/browse/CMTOOL-418

## Summary

Adds a small wiki under `_context/wiki/` and an `AGENTS.md` file at the repo root to provide persistent, structured context for AI coding agents (and human contributors).

### Changes

**New files**
- `AGENTS.md` — root-level rules telling AI agents to check the wiki index at task start and offer to update it after tasks that yield durable knowledge.
- `_context/wiki/index.md` — entry point: quick-facts block and a table linking to all wiki pages and the existing READMEs.
- `_context/wiki/project.md` — developer context not duplicated in the READMEs: goals, stakeholders, repo layout, key modules (`core`, `servers/wildfly10.0`, `servers/wildfly41.0`), architecture notes, and workflow pointers.
- `_context/wiki/preferences.md` — code style, AI collaboration rules, and commit/PR conventions (with links to `CONTRIBUTING.md` as the canonical source).

**Modified files**
- `README.md` — updates stale example server version references (wildfly-29.0.0.Final → 41.0, wildfly-39.0.0.Final → 42.0.0.Final-SNAPSHOT).
- `CONTRIBUTING.md` — fixes JDK requirement (JDK 8 → JDK 17+, matching the actual system requirements).

### Design principle

The wiki pages do not duplicate information already in `README.md`, `CONTRIBUTING.md`, `maintenance/README.md`, or `testsuite/README.md`. They link to those files instead and only capture context that isn't covered elsewhere.