### PR TITLE
[CMTOOL-416] Migrate Elytron OIDC Client configuration referenced paths

### DIFF
--- a/servers/wildfly41.0/src/main/java/org/jboss/migration/wfly/task/paths/ElytronOidcClientSubsystemPathsMigration.java
+++ b/servers/wildfly41.0/src/main/java/org/jboss/migration/wfly/task/paths/ElytronOidcClientSubsystemPathsMigration.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.migration.wfly.task.paths;
+
+import org.jboss.migration.core.jboss.JBossServerConfiguration;
+import org.jboss.migration.core.jboss.MigrateResolvablePathTaskBuilder;
+import org.jboss.migration.core.jboss.ResolvablePath;
+import org.jboss.migration.core.jboss.XmlConfigurationMigration;
+import org.jboss.migration.core.task.ServerMigrationTaskResult;
+import org.jboss.migration.core.task.TaskContext;
+import org.jboss.migration.core.task.component.SimpleComponentTask;
+import org.jboss.migration.core.task.component.TaskSkipPolicy;
+
+import javax.xml.stream.XMLStreamReader;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Migration of paths referenced by the Elytron OIDC Client subsystem XML configuration.
+ * Handles {@code client-keystore} and {@code truststore} elements (via the {@code file} attribute),
+ * the {@code client-keystore-file} attribute on {@code credential} elements, and the
+ * {@code request-object-signing-keystore-file} element (via the {@code file} attribute).
+ * @author emmartins
+ */
+public class ElytronOidcClientSubsystemPathsMigration implements XmlConfigurationMigration.Component {
+
+    /**
+     *
+     */
+    public static class Factory implements XmlConfigurationMigration.ComponentFactory {
+        @Override
+        public XmlConfigurationMigration.Component newComponent() {
+            return new ElytronOidcClientSubsystemPathsMigration();
+        }
+    }
+
+    private static final String NAMESPACE_URI_PREFIX = "urn:wildfly:elytron-oidc-client:";
+
+    public static final Set<String> ELEMENT_LOCAL_NAMES = Set.of(
+            "client-keystore",
+            "truststore",
+            "credential",
+            "request-object-signing-keystore-file"
+    );
+
+    private static final String ATTR_FILE = "file";
+    private static final String ATTR_CLIENT_KEYSTORE_FILE = "client-keystore-file";
+
+    protected final Set<String> files;
+
+    protected ElytronOidcClientSubsystemPathsMigration() {
+        files = new HashSet<>();
+    }
+
+    @Override
+    public Set<String> getElementLocalNames() {
+        return ELEMENT_LOCAL_NAMES;
+    }
+
+    @Override
+    public void processElement(XMLStreamReader reader, JBossServerConfiguration sourceConfiguration, JBossServerConfiguration targetConfiguration, TaskContext context) throws IOException {
+        final String namespaceURI = reader.getNamespaceURI();
+        if (namespaceURI == null || !namespaceURI.startsWith(NAMESPACE_URI_PREFIX)) {
+            return;
+        }
+        final String localName = reader.getLocalName();
+        if ("credential".equals(localName)) {
+            // credential element uses a dedicated attribute name for the keystore file path
+            final String clientKeystoreFile = reader.getAttributeValue(null, ATTR_CLIENT_KEYSTORE_FILE);
+            if (clientKeystoreFile != null) {
+                files.add(clientKeystoreFile);
+            }
+        } else {
+            // client-keystore, truststore, request-object-signing-keystore-file all use a 'file' attribute
+            final String file = reader.getAttributeValue(null, ATTR_FILE);
+            if (file != null) {
+                files.add(file);
+            }
+        }
+    }
+
+    @Override
+    public void afterProcessingElements(JBossServerConfiguration sourceConfiguration, JBossServerConfiguration targetConfiguration, TaskContext taskContext) {
+        taskContext.execute(new SimpleComponentTask.Builder()
+                .name(taskContext.getTaskName().getName() + ".subsystem.elytron-oidc-client")
+                .skipPolicy(TaskSkipPolicy.skipIfDefaultTaskSkipPropertyIsSet())
+                .runnable(context -> {
+                    final String subtaskNamePrefix = context.getTaskName() + ".file";
+                    for (String file : files) {
+                        context.execute(new MigrateResolvablePathTaskBuilder()
+                                .name(subtaskNamePrefix)
+                                .path(ResolvablePath.fromPathExpression(file))
+                                .source(sourceConfiguration)
+                                .target(targetConfiguration)
+                                .skipIfSourcePathDoesNotExists(true)
+                                .build());
+                    }
+                    return context.hasSucessfulSubtasks() ? ServerMigrationTaskResult.SUCCESS : ServerMigrationTaskResult.SKIPPED;
+                })
+                .build());
+    }
+}

--- a/servers/wildfly41.0/src/main/java/org/jboss/migration/wfly/task/paths/WildFly41_0MigrateReferencedPaths.java
+++ b/servers/wildfly41.0/src/main/java/org/jboss/migration/wfly/task/paths/WildFly41_0MigrateReferencedPaths.java
@@ -19,6 +19,7 @@ public class WildFly41_0MigrateReferencedPaths<S extends JBossServer<S>> extends
                 .componentFactory(new VaultPathsMigration.Factory())
                 .componentFactory(new WebSubsystemPathsMigration.Factory())
                 .componentFactory(new ModclusterSubsystemPathsMigration.Factory())
+                .componentFactory(new ElytronOidcClientSubsystemPathsMigration.Factory())
                 .componentFactory(new AttributesResolvablePathsMigration.Factory())
         );
     }

--- a/servers/wildfly41.0/src/test/java/org/jboss/migration/wfly/task/paths/ElytronOidcClientSubsystemPathsMigrationTest.java
+++ b/servers/wildfly41.0/src/test/java/org/jboss/migration/wfly/task/paths/ElytronOidcClientSubsystemPathsMigrationTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright The WildFly Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.migration.wfly.task.paths;
+
+import org.jboss.migration.core.jboss.XmlConfigurationMigration;
+import org.jboss.migration.wfly10.config.task.paths.AbstractXmlConfigurationMigrationComponentTest;
+
+import java.util.List;
+
+/**
+ * Unit test for {@link ElytronOidcClientSubsystemPathsMigration}.
+ * @author emmartins
+ */
+public class ElytronOidcClientSubsystemPathsMigrationTest extends AbstractXmlConfigurationMigrationComponentTest {
+
+    @Override
+    protected String getXmlConfig() {
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<server xmlns=\"urn:jboss:domain:1.7\">\n"
+                + "  <subsystem xmlns=\"urn:wildfly:elytron-oidc-client:3.0\">\n"
+                + "    <realm name=\"myrealm\">\n"
+                + "      <client-keystore file=\"${jboss.home.dir}/standalone/data/realm-client.jks\"/>\n"
+                + "      <truststore file=\"${jboss.home.dir}/standalone/data/realm-trust.jks\"/>\n"
+                + "    </realm>\n"
+                + "    <provider name=\"myprovider\">\n"
+                + "      <client-keystore file=\"${jboss.home.dir}/standalone/data/provider-client.jks\"/>\n"
+                + "      <truststore file=\"${jboss.home.dir}/standalone/data/provider-trust.jks\"/>\n"
+                + "    </provider>\n"
+                + "    <secure-deployment name=\"myapp.war\">\n"
+                + "      <client-keystore file=\"${jboss.home.dir}/standalone/data/deployment-client.jks\"/>\n"
+                + "      <truststore file=\"${jboss.home.dir}/standalone/data/deployment-trust.jks\"/>\n"
+                + "      <credential client-keystore-file=\"${jboss.home.dir}/standalone/data/credential-client.jks\"/>\n"
+                + "    </secure-deployment>\n"
+                + "    <secure-server name=\"myserver\">\n"
+                + "      <client-keystore file=\"${jboss.home.dir}/standalone/data/server-client.jks\"/>\n"
+                + "      <truststore file=\"${jboss.home.dir}/standalone/data/server-trust.jks\"/>\n"
+                + "    </secure-server>\n"
+                + "  </subsystem>\n"
+                + "  <subsystem xmlns=\"urn:wildfly:elytron-oidc-client:preview:4.0\">\n"
+                + "    <realm name=\"preview-realm\">\n"
+                + "      <request-object-signing-keystore-file file=\"${jboss.home.dir}/standalone/data/preview-signing.jks\"/>\n"
+                + "    </realm>\n"
+                + "  </subsystem>\n"
+                + "</server>\n";
+    }
+
+    @Override
+    protected XmlConfigurationMigration.ComponentFactory getComponentFactory() {
+        return new ElytronOidcClientSubsystemPathsMigration.Factory();
+    }
+
+    @Override
+    protected List<String> getExpectedCopiedPaths() {
+        return List.of(
+                "standalone/data/realm-client.jks",
+                "standalone/data/realm-trust.jks",
+                "standalone/data/provider-client.jks",
+                "standalone/data/provider-trust.jks",
+                "standalone/data/deployment-client.jks",
+                "standalone/data/deployment-trust.jks",
+                "standalone/data/credential-client.jks",
+                "standalone/data/server-client.jks",
+                "standalone/data/server-trust.jks",
+                "standalone/data/preview-signing.jks"
+        );
+    }
+}


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/CMTOOL-416

Adds migration of file paths referenced by the Elytron OIDC Client subsystem configuration, which uses non-standard path attributes rather than the usual \`path\`/\`relative-to\` pair.

**What's added:**

- \`ElytronOidcClientSubsystemPathsMigration\` — a new \`XmlConfigurationMigration.Component\` that handles all path-bearing elements in the \`urn:wildfly:elytron-oidc-client:\` namespace (covering both 3.0 and preview 4.0):
  - \`client-keystore/@file\`
  - \`truststore/@file\`
  - \`credential/@client-keystore-file\`
  - \`request-object-signing-keystore-file/@file\`
- Registered in \`WildFly41_0MigrateReferencedPaths\`, picked up automatically by all existing and future migration providers.
- Unit test extending \`AbstractXmlConfigurationMigrationComponentTest\` covering all element/attribute combinations.